### PR TITLE
Add name filter option to x-java-home tool

### DIFF
--- a/x-java-home/README.md
+++ b/x-java-home/README.md
@@ -24,6 +24,7 @@ Usage: x-java-home [OPTIONS]
 Options:
   -v, --version <VERSION>    Filter versions (as if JAVA_VERSION had been set in the environment)
   -a, --arch <ARCH>          Filter architecture (as if JAVA_ARCH had been set in the environment)
+  -n, --name <NAME>          Filter by JVM name (case-insensitive substring match)
   -F, --failfast             Fail when filters return no JVMs, do not continue with default
       --exec <EXEC>...       Execute the $JAVA_HOME/bin/<command> with the remaining arguments
       --json                 Print full JVM list and additional data as JSON
@@ -53,6 +54,28 @@ x-java-home -v 21
 Output:
 ```
 /Library/Java/JavaVirtualMachines/zulu-21.jdk/Contents/Home
+```
+
+#### Filter by JVM name
+
+```bash
+x-java-home -n graal
+```
+
+Output:
+```
+/Library/Java/JavaVirtualMachines/graalvm-25.jdk/Contents/Home
+```
+
+#### Combine filters (version and name)
+
+```bash
+x-java-home -v 25 -n graal
+```
+
+Output:
+```
+/Library/Java/JavaVirtualMachines/graalvm-25.jdk/Contents/Home
 ```
 
 #### Get all JVMs in verbose format
@@ -112,6 +135,14 @@ x-java-home -v 21 --json
 
 This will return JSON data for Java 21 installations.
 
+#### Filter by name with JSON output
+
+```bash
+x-java-home -n zulu --json
+```
+
+This will return JSON data for all Zulu JDK installations.
+
 #### Execute a command with a specific Java version
 
 ```bash
@@ -140,9 +171,10 @@ x-java-home --json
 
 ## Differences from java_home
 
-The only difference from the standard `/usr/libexec/java_home` tool is:
+The differences from the standard `/usr/libexec/java_home` tool are:
 
 - **Removed:** `-X/--xml` flag (XML output)
 - **Added:** `--json` flag (JSON output)
+- **Added:** `-n/--name` flag (filter by JVM name with case-insensitive substring matching)
 
 All other functionality remains identical.

--- a/x-java-home/src/main.rs
+++ b/x-java-home/src/main.rs
@@ -41,6 +41,10 @@ struct Args {
     #[arg(short = 'a', long = "arch")]
     arch: Option<String>,
 
+    /// Filter by JVM name (case-insensitive substring match)
+    #[arg(short = 'n', long = "name")]
+    name: Option<String>,
+
     /// Fail when filters return no JVMs, do not continue with default
     #[arg(short = 'F', long = "failfast")]
     failfast: bool,
@@ -61,34 +65,26 @@ struct Args {
 fn main() -> Result<()> {
     let args = Args::parse();
 
-    // Build the java_home command
-    let mut cmd = Command::new("/usr/libexec/java_home");
-
-    // Add version filter if provided
-    if let Some(version) = &args.version {
-        cmd.arg("-v").arg(version);
-    }
-
-    // Add architecture filter if provided
-    if let Some(arch) = &args.arch {
-        cmd.arg("-a").arg(arch);
-    }
-
-    // Add failfast flag if provided
-    if args.failfast {
-        cmd.arg("-F");
-    }
-
-    // Handle --exec flag
-    if let Some(exec_args) = &args.exec {
-        cmd.arg("--exec");
-        cmd.args(exec_args);
-    }
-
-    // Handle --json flag
-    if args.json {
-        // Request XML output from java_home
+    // If --name or --json is provided, we need to fetch and parse the XML output
+    if args.name.is_some() || args.json {
+        // Build the java_home command with -X flag to get XML output
+        let mut cmd = Command::new("/usr/libexec/java_home");
         cmd.arg("-X");
+
+        // Add version filter if provided
+        if let Some(version) = &args.version {
+            cmd.arg("-v").arg(version);
+        }
+
+        // Add architecture filter if provided
+        if let Some(arch) = &args.arch {
+            cmd.arg("-a").arg(arch);
+        }
+
+        // Add failfast flag if provided
+        if args.failfast {
+            cmd.arg("-F");
+        }
 
         let output = cmd.output().context("Failed to execute java_home")?;
 
@@ -98,18 +94,59 @@ fn main() -> Result<()> {
         }
 
         // Parse the plist XML
-        let jvms: Vec<JVMInfo> = plist::from_bytes(&output.stdout)
+        let mut jvms: Vec<JVMInfo> = plist::from_bytes(&output.stdout)
             .context("Failed to parse plist XML from java_home")?;
 
-        // Create output structure
-        let json_output = Output { jvms };
+        // Filter by name if provided
+        if let Some(name_filter) = &args.name {
+            let name_lower = name_filter.to_lowercase();
+            jvms.retain(|jvm| jvm.JVMName.to_lowercase().contains(&name_lower));
+        }
 
-        // Serialize to JSON and print
-        let json = serde_json::to_string_pretty(&json_output)
-            .context("Failed to serialize to JSON")?;
+        // Handle output
+        if args.json {
+            // Create output structure
+            let json_output = Output { jvms };
 
-        println!("{}", json);
+            // Serialize to JSON and print
+            let json = serde_json::to_string_pretty(&json_output)
+                .context("Failed to serialize to JSON")?;
+
+            println!("{}", json);
+        } else {
+            // Output the first matching JVM's home path
+            if let Some(jvm) = jvms.first() {
+                println!("{}", jvm.JVMHomePath);
+            } else {
+                eprintln!("No matching JVM found");
+                std::process::exit(1);
+            }
+        }
     } else {
+        // Pass through to java_home for standard behavior
+        let mut cmd = Command::new("/usr/libexec/java_home");
+
+        // Add version filter if provided
+        if let Some(version) = &args.version {
+            cmd.arg("-v").arg(version);
+        }
+
+        // Add architecture filter if provided
+        if let Some(arch) = &args.arch {
+            cmd.arg("-a").arg(arch);
+        }
+
+        // Add failfast flag if provided
+        if args.failfast {
+            cmd.arg("-F");
+        }
+
+        // Handle --exec flag
+        if let Some(exec_args) = &args.exec {
+            cmd.arg("--exec");
+            cmd.args(exec_args);
+        }
+
         // Add verbose flag if provided
         if args.verbose {
             cmd.arg("-V");


### PR DESCRIPTION
Implements a new -n/--name option that filters JVMs by name using case-insensitive substring matching. Since the underlying /usr/libexec/java_home doesn't support name filtering, this is implemented by:

- Fetching all JVMs with the -X flag (along with any other supported filters like -v and -a)
- Parsing the XML output and filtering by JVMName
- In default mode, outputting the first matching JVM path
- With --json flag, outputting all matching JVMs as JSON

Example usage:
  x-java-home -v 25 -n graal x-java-home -n zulu --json