### PR TITLE
Create git repos latest activity tool

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,3 +19,14 @@ The table format is:
 ```
 
 Each tool name should be a link to its directory, and the description should be concise (one line).
+
+## Java Code Formatting
+
+All Java code in this repository must be formatted with **4-space indentation**. This applies to:
+
+- Class and method bodies
+- Control structures (if, for, while, etc.)
+- Method chaining and fluent APIs
+- All other indented code blocks
+
+Do not use tabs for indentation in Java files.

--- a/README.md
+++ b/README.md
@@ -7,4 +7,5 @@ A collection of small tools.
 | Tool | Description |
 |------|-------------|
 | [git-dirty-checker-java](git-dirty-checker-java/) | Checks git repositories for uncommitted changes |
+| [git-repos-latest-activity](git-repos-latest-activity/) | Lists git repositories sorted by date of latest commit |
 | [x-java-home](x-java-home/) | A drop-in replacement for macOS java_home with JSON output support |

--- a/git-repos-latest-activity/.editorconfig
+++ b/git-repos-latest-activity/.editorconfig
@@ -1,0 +1,13 @@
+# https://EditorConfig.org
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+charset = utf-8
+
+[*.java]
+indent_style = space
+indent_size = 4
+
+[Makefile]
+indent_style = tab

--- a/git-repos-latest-activity/.gitignore
+++ b/git-repos-latest-activity/.gitignore
@@ -1,0 +1,1 @@
+git-repos-latest-activity

--- a/git-repos-latest-activity/Makefile
+++ b/git-repos-latest-activity/Makefile
@@ -1,0 +1,14 @@
+GRAALVM_HOME=/Library/Java/JavaVirtualMachines/graalvm-25.jdk/Contents/Home
+
+git-repos-latest-activity:
+	JAVA_HOME=$(GRAALVM_HOME) mvn compile
+	JAVA_HOME=$(GRAALVM_HOME) $(GRAALVM_HOME)/bin/native-image -classpath ./target/classes -o git-repos-latest-activity tech.skagedal.GitReposLatestActivity
+
+install: git-repos-latest-activity
+	cp git-repos-latest-activity ~/local/bin/git-repos-latest-activity
+
+clean:
+	mvn clean
+	rm -f git-repos-latest-activity
+
+.PHONY: clean install

--- a/git-repos-latest-activity/pom.xml
+++ b/git-repos-latest-activity/pom.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>tech.skagedal</groupId>
+    <artifactId>git-repos-latest-activity</artifactId>
+    <version>1.0-SNAPSHOT</version>
+
+    <properties>
+        <maven.compiler.source>25</maven.compiler.source>
+        <maven.compiler.target>25</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+</project>

--- a/git-repos-latest-activity/src/main/java/tech/skagedal/GitReposLatestActivity.java
+++ b/git-repos-latest-activity/src/main/java/tech/skagedal/GitReposLatestActivity.java
@@ -5,79 +5,65 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Instant;
 import java.util.*;
-import java.util.stream.Collectors;
 
 public class GitReposLatestActivity {
-  record RepoActivity(Path path, Instant timestamp) implements Comparable<RepoActivity> {
-    @Override
-    public int compareTo(RepoActivity other) {
-      return this.timestamp.compareTo(other.timestamp);
+    record RepoActivity(Path path, Instant timestamp) implements Comparable<RepoActivity> {
+        @Override
+        public int compareTo(RepoActivity other) {
+            return this.timestamp.compareTo(other.timestamp);
+        }
     }
-  }
 
-  static Optional<Instant> getLatestCommitTime(final Path path) {
-    final var processBuilder = new ProcessBuilder()
-        .directory(path.toFile())
-        .command("git", "log", "-1", "--format=%cI");
-    try {
-      final var process = processBuilder.start();
-      final var exitCode = process.waitFor();
-      if (exitCode != 0) {
-        // Not a git repository or no commits
-        return Optional.empty();
-      }
-      final var output = new String(process.getInputStream().readAllBytes()).trim();
-      if (output.isBlank()) {
-        return Optional.empty();
-      }
-      return Optional.of(Instant.parse(output));
-    } catch (IOException | InterruptedException e) {
-      // Failed to check git status, skip this directory
-      return Optional.empty();
+    static Instant getLatestCommitTime(final Path path) {
+        final var processBuilder = new ProcessBuilder()
+            .directory(path.toFile())
+            .command("git", "log", "-1", "--format=%cI");
+        try {
+            final var process = processBuilder.start();
+            final var exitCode = process.waitFor();
+            if (exitCode != 0) {
+                throw new RuntimeException("Git command failed with exit code " + exitCode + " in " + path);
+            }
+            final var output = new String(process.getInputStream().readAllBytes()).trim();
+            if (output.isBlank()) {
+                throw new RuntimeException("No commits found in " + path);
+            }
+            return Instant.parse(output);
+        } catch (IOException | InterruptedException e) {
+            throw new RuntimeException("Failed to get latest commit time in " + path, e);
+        }
     }
-  }
 
-  static Collection<Path> findRepositories(List<Path> topPaths) throws IOException {
-    final var repositories = new ArrayList<Path>();
-    for (final var path : topPaths) {
-      try (final var stream = Files.list(path)) {
-        stream.forEach(repositories::add);
-      }
+    static Collection<Path> findRepositories(List<Path> topPaths) throws IOException {
+        final var repositories = new ArrayList<Path>();
+        for (final var path : topPaths) {
+            try (final var stream = Files.list(path)) {
+                stream.forEach(repositories::add);
+            }
+        }
+        return repositories;
     }
-    return repositories;
-  }
 
-  static boolean isGitRepository(Path path) {
-    return Files.isDirectory(path.resolve(".git"));
-  }
+    static void printRepoActivities(List<Path> topPaths) {
+        try {
+            final var activities = findRepositories(topPaths)
+                .stream()
+                .parallel()
+                .filter(Files::isDirectory)
+                .map(p -> new RepoActivity(p, getLatestCommitTime(p)))
+                .sorted()
+                .toList();
 
-  static void printRepoActivities(List<Path> topPaths) {
-    try {
-      final var activities = findRepositories(topPaths)
-          .stream()
-          .parallel()
-          .filter(Files::isDirectory)
-          .filter(p -> !p.getFileName().toString().equals(".git"))
-          .filter(GitReposLatestActivity::isGitRepository)
-          .map(p -> {
-            final var timestamp = getLatestCommitTime(p);
-            return timestamp.map(instant -> new RepoActivity(p, instant));
-          })
-          .filter(Optional::isPresent)
-          .map(Optional::get)
-          .sorted()
-          .toList();
-
-      activities.forEach(activity ->
-          System.out.println(activity.path + " " + activity.timestamp)
-      );
-    } catch (IOException e) {
-      throw new RuntimeException("Failed to list subdirectories", e);
+            activities.forEach(activity ->
+                System.out.println(activity.path + " " + activity.timestamp)
+            );
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to list subdirectories", e);
+        }
     }
-  }
 
-  public static void main(String[] args) {
-    final var paths = Arrays.stream(args).map(Path::of).toList();
-    printRepoActivities(paths);
-  }
+    public static void main(String[] args) {
+        final var paths = Arrays.stream(args).map(Path::of).toList();
+        printRepoActivities(paths);
+    }
 }

--- a/git-repos-latest-activity/src/main/java/tech/skagedal/GitReposLatestActivity.java
+++ b/git-repos-latest-activity/src/main/java/tech/skagedal/GitReposLatestActivity.java
@@ -1,0 +1,83 @@
+package tech.skagedal;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.*;
+import java.util.stream.Collectors;
+
+public class GitReposLatestActivity {
+  record RepoActivity(Path path, Instant timestamp) implements Comparable<RepoActivity> {
+    @Override
+    public int compareTo(RepoActivity other) {
+      return this.timestamp.compareTo(other.timestamp);
+    }
+  }
+
+  static Optional<Instant> getLatestCommitTime(final Path path) {
+    final var processBuilder = new ProcessBuilder()
+        .directory(path.toFile())
+        .command("git", "log", "-1", "--format=%cI");
+    try {
+      final var process = processBuilder.start();
+      final var exitCode = process.waitFor();
+      if (exitCode != 0) {
+        // Not a git repository or no commits
+        return Optional.empty();
+      }
+      final var output = new String(process.getInputStream().readAllBytes()).trim();
+      if (output.isBlank()) {
+        return Optional.empty();
+      }
+      return Optional.of(Instant.parse(output));
+    } catch (IOException | InterruptedException e) {
+      // Failed to check git status, skip this directory
+      return Optional.empty();
+    }
+  }
+
+  static Collection<Path> findRepositories(List<Path> topPaths) throws IOException {
+    final var repositories = new ArrayList<Path>();
+    for (final var path : topPaths) {
+      try (final var stream = Files.list(path)) {
+        stream.forEach(repositories::add);
+      }
+    }
+    return repositories;
+  }
+
+  static boolean isGitRepository(Path path) {
+    return Files.isDirectory(path.resolve(".git"));
+  }
+
+  static void printRepoActivities(List<Path> topPaths) {
+    try {
+      final var activities = findRepositories(topPaths)
+          .stream()
+          .parallel()
+          .filter(Files::isDirectory)
+          .filter(p -> !p.getFileName().toString().equals(".git"))
+          .filter(GitReposLatestActivity::isGitRepository)
+          .map(p -> {
+            final var timestamp = getLatestCommitTime(p);
+            return timestamp.map(instant -> new RepoActivity(p, instant));
+          })
+          .filter(Optional::isPresent)
+          .map(Optional::get)
+          .sorted()
+          .toList();
+
+      activities.forEach(activity ->
+          System.out.println(activity.path + " " + activity.timestamp)
+      );
+    } catch (IOException e) {
+      throw new RuntimeException("Failed to list subdirectories", e);
+    }
+  }
+
+  public static void main(String[] args) {
+    final var paths = Arrays.stream(args).map(Path::of).toList();
+    printRepoActivities(paths);
+  }
+}


### PR DESCRIPTION
Implements a new tool that lists git repositories sorted by the date of their latest commit. The tool takes parent directories as arguments, finds all git repositories within them, and outputs each repository's path and latest commit timestamp in ISO format, sorted from oldest to newest.

The implementation uses parallel processing for performance, similar to git-dirty-checker-java.