### PR TITLE
Add rds-ssh-tunnel tool for PostgreSQL database access via SSH tunnel

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,4 +8,5 @@ A collection of small tools.
 |------|-------------|
 | [git-dirty-checker-java](git-dirty-checker-java/) | Checks git repositories for uncommitted changes |
 | [git-repos-latest-activity](git-repos-latest-activity/) | Lists git repositories sorted by date of latest commit |
+| [rds-ssh-tunnel](rds-ssh-tunnel/) | Connect to PostgreSQL databases via SSH tunnel to a bastion host, optimized for AWS RDS |
 | [x-java-home](x-java-home/) | A drop-in replacement for macOS java_home with JSON output support |

--- a/rds-ssh-tunnel/.gitignore
+++ b/rds-ssh-tunnel/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+dist/
+*.log
+.env

--- a/rds-ssh-tunnel/README.md
+++ b/rds-ssh-tunnel/README.md
@@ -1,0 +1,157 @@
+# rds-ssh-tunnel
+
+A TypeScript tool for connecting to PostgreSQL databases via an SSH tunnel to a bastion host, optimized for AWS RDS.
+
+## Features
+
+- Creates SSH tunnel to bastion host using the ssh2 library
+- Connects to PostgreSQL databases through the tunnel
+- Optimized for AWS RDS databases
+- Built with TypeScript and runs directly using Node.js native TypeScript support
+- Comprehensive CLI argument parsing
+- Optional database connection testing
+- Graceful shutdown handling
+
+## Prerequisites
+
+- Node.js version 22.6.0 or higher (with `--experimental-strip-types` support)
+- SSH access to a bastion host
+- PostgreSQL database accessible from the bastion host
+
+## Installation
+
+```bash
+cd rds-ssh-tunnel
+npm install
+```
+
+## Usage
+
+### Basic Usage
+
+```bash
+npm start -- \
+  --bastion-host bastion.example.com \
+  --db-host my-rds-instance.abc123.us-east-1.rds.amazonaws.com
+```
+
+### Full Example with All Options
+
+```bash
+npm start -- \
+  --bastion-host bastion.example.com \
+  --bastion-port 22 \
+  --bastion-user ec2-user \
+  --bastion-key ~/.ssh/my-key.pem \
+  --db-host my-rds-instance.abc123.us-east-1.rds.amazonaws.com \
+  --db-port 5432 \
+  --db-user postgres \
+  --db-password mypassword \
+  --db-name mydatabase \
+  --local-port 5433 \
+  --test \
+  --keep-alive
+```
+
+### Using Password Authentication (instead of SSH key)
+
+```bash
+npm start -- \
+  --bastion-host bastion.example.com \
+  --bastion-password mysshpassword \
+  --db-host my-rds-instance.abc123.us-east-1.rds.amazonaws.com
+```
+
+### Direct Execution (with executable permissions)
+
+```bash
+chmod +x src/index.ts
+./src/index.ts --bastion-host bastion.example.com --db-host my-db.rds.amazonaws.com
+```
+
+## CLI Options
+
+| Option | Short | Description | Default |
+|--------|-------|-------------|---------|
+| `--bastion-host` | `-bh` | Bastion host address (required) | - |
+| `--bastion-port` | `-bp` | Bastion SSH port | `22` |
+| `--bastion-user` | `-bu` | Bastion SSH username | `$USER` or `ec2-user` |
+| `--bastion-key` | `-bk` | Path to SSH private key | `~/.ssh/id_rsa` |
+| `--bastion-password` | `-bpw` | SSH password (alternative to key) | - |
+| `--db-host` | `-dh` | Database host/RDS endpoint (required) | - |
+| `--db-port` | `-dp` | Database port | `5432` |
+| `--db-user` | `-du` | Database username | `postgres` |
+| `--db-password` | `-dpw` | Database password | - |
+| `--db-name` | `-dn` | Database name | `postgres` |
+| `--local-port` | `-lp` | Local port for tunnel | `5433` |
+| `--test` | - | Test database connection | `false` |
+| `--keep-alive` | - | Keep tunnel alive after test | `false` |
+
+## AWS RDS Example
+
+For an AWS RDS PostgreSQL instance accessed through an EC2 bastion host:
+
+```bash
+npm start -- \
+  --bastion-host ec2-54-123-45-67.compute-1.amazonaws.com \
+  --bastion-user ec2-user \
+  --bastion-key ~/.ssh/aws-key.pem \
+  --db-host myapp-db.c9akd8fjqk3l.us-east-1.rds.amazonaws.com \
+  --db-user dbadmin \
+  --db-password 'MySecurePassword123!' \
+  --db-name production \
+  --test \
+  --keep-alive
+```
+
+This will:
+1. Connect to the EC2 bastion host via SSH
+2. Establish a tunnel from `localhost:5433` to the RDS instance
+3. Test the PostgreSQL connection
+4. Keep the tunnel alive for further use
+
+You can then connect to the database using any PostgreSQL client:
+
+```bash
+psql postgresql://dbadmin@localhost:5433/production
+```
+
+## How It Works
+
+1. **SSH Connection**: The tool establishes an SSH connection to your bastion host using either a private key or password
+2. **Port Forwarding**: Creates a local port (default: 5433) that forwards traffic through the SSH tunnel
+3. **Database Access**: Routes PostgreSQL traffic through the tunnel to your RDS instance
+4. **Connection Testing**: Optionally tests the connection and displays database version info
+5. **Keep Alive**: Can maintain the tunnel for ongoing use or exit after testing
+
+## Security Notes
+
+- Never commit passwords or private keys to version control
+- Use environment variables or secure credential management for sensitive data
+- Consider using AWS Systems Manager Session Manager as an alternative to traditional bastion hosts
+- Ensure your security groups allow PostgreSQL traffic from the bastion host to RDS
+
+## Troubleshooting
+
+### SSH Connection Fails
+
+- Verify bastion host address and SSH credentials
+- Check that your SSH key has proper permissions (`chmod 600 ~/.ssh/key.pem`)
+- Ensure security groups allow SSH (port 22) to bastion host
+
+### Database Connection Fails
+
+- Verify RDS endpoint is correct
+- Check that RDS security group allows PostgreSQL (port 5432) from bastion host
+- Confirm database credentials are correct
+- Ensure RDS instance is in a state that accepts connections
+
+### Tunnel Closes Unexpectedly
+
+- Check for network connectivity issues
+- Verify SSH session timeout settings on bastion host
+- Consider implementing keep-alive packets for long-running tunnels
+
+## License
+
+ISC

--- a/rds-ssh-tunnel/package-lock.json
+++ b/rds-ssh-tunnel/package-lock.json
@@ -1,0 +1,314 @@
+{
+  "name": "rds-ssh-tunnel",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "rds-ssh-tunnel",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "commander": "^12.1.0",
+        "pg": "^8.13.1",
+        "ssh2": "^1.16.0"
+      },
+      "bin": {
+        "rds-ssh-tunnel": "src/index.ts"
+      },
+      "devDependencies": {
+        "@types/node": "^22.10.2",
+        "@types/pg": "^8.11.10",
+        "@types/ssh2": "^1.15.1"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "22.19.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.3.tgz",
+      "integrity": "sha512-1N9SBnWYOJTrNZCdh/yJE+t910Y128BoyY+zBLWhL3r0TYzlTmFdXrPwHL9DyFZmlEXNQQolTZh3KHV31QDhyA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/pg": {
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.16.0.tgz",
+      "integrity": "sha512-RmhMd/wD+CF8Dfo+cVIy3RR5cl8CyfXQ0tGgW6XBL8L4LM/UTEbNXYRbLwU6w+CgrKBNbrQWt4FUtTfaU5jSYQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "pg-protocol": "*",
+        "pg-types": "^2.2.0"
+      }
+    },
+    "node_modules/@types/ssh2": {
+      "version": "1.15.5",
+      "resolved": "https://registry.npmjs.org/@types/ssh2/-/ssh2-1.15.5.tgz",
+      "integrity": "sha512-N1ASjp/nXH3ovBHddRJpli4ozpk6UdDYIX4RJWFa9L1YKnzdhTlVmiGHm4DZnj/jLbqZpes4aeR30EFGQtvhQQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^18.11.18"
+      }
+    },
+    "node_modules/@types/ssh2/node_modules/@types/node": {
+      "version": "18.19.130",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
+      "integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/@types/ssh2/node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/asn1": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
+      "integrity": "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": "~2.1.0"
+      }
+    },
+    "node_modules/bcrypt-pbkdf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+      "integrity": "sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tweetnacl": "^0.14.3"
+      }
+    },
+    "node_modules/buildcheck": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/buildcheck/-/buildcheck-0.0.7.tgz",
+      "integrity": "sha512-lHblz4ahamxpTmnsk+MNTRWsjYKv965MwOrSJyeD588rR3Jcu7swE+0wN5F+PbL5cjgu/9ObkhfzEPuofEMwLA==",
+      "optional": true,
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/commander": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/cpu-features": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/cpu-features/-/cpu-features-0.0.10.tgz",
+      "integrity": "sha512-9IkYqtX3YHPCzoVg1Py+o9057a3i0fp7S530UWokCSaFVTc7CwXPRiOjRjBQQ18ZCNafx78YfnG+HALxtVmOGA==",
+      "hasInstallScript": true,
+      "optional": true,
+      "dependencies": {
+        "buildcheck": "~0.0.6",
+        "nan": "^2.19.0"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/nan": {
+      "version": "2.24.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.24.0.tgz",
+      "integrity": "sha512-Vpf9qnVW1RaDkoNKFUvfxqAbtI8ncb8OJlqZ9wwpXzWPEsvsB1nvdUi6oYrHIkQ1Y/tMDnr1h4nczS0VB9Xykg==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/pg": {
+      "version": "8.16.3",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.16.3.tgz",
+      "integrity": "sha512-enxc1h0jA/aq5oSDMvqyW3q89ra6XIIDZgCX9vkMrnz5DFTw/Ny3Li2lFQ+pt3L6MCgm/5o2o8HW9hiJji+xvw==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-connection-string": "^2.9.1",
+        "pg-pool": "^3.10.1",
+        "pg-protocol": "^1.10.3",
+        "pg-types": "2.2.0",
+        "pgpass": "1.0.5"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "optionalDependencies": {
+        "pg-cloudflare": "^1.2.7"
+      },
+      "peerDependencies": {
+        "pg-native": ">=3.0.1"
+      },
+      "peerDependenciesMeta": {
+        "pg-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pg-cloudflare": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.2.7.tgz",
+      "integrity": "sha512-YgCtzMH0ptvZJslLM1ffsY4EuGaU0cx4XSdXLRFae8bPP4dS5xL1tNB3k2o/N64cHJpwU7dxKli/nZ2lUa5fLg==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/pg-connection-string": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.9.1.tgz",
+      "integrity": "sha512-nkc6NpDcvPVpZXxrreI/FOtX3XemeLl8E0qFr6F2Lrm/I8WOnaWNhIPK2Z7OHpw7gh5XJThi6j6ppgNoaT1w4w==",
+      "license": "MIT"
+    },
+    "node_modules/pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/pg-pool": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.10.1.tgz",
+      "integrity": "sha512-Tu8jMlcX+9d8+QVzKIvM/uJtp07PKr82IUOYEphaWcoBhIYkoHpLXN3qO59nAI11ripznDsEzEv8nUxBVWajGg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "pg": ">=8.0"
+      }
+    },
+    "node_modules/pg-protocol": {
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.10.3.tgz",
+      "integrity": "sha512-6DIBgBQaTKDJyxnXaLiLR8wBpQQcGWuAESkRBX/t6OwA8YsqP+iVSiond2EDy6Y/dsGk8rh/jtax3js5NeV7JQ==",
+      "license": "MIT"
+    },
+    "node_modules/pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pgpass": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
+      "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.1.0"
+      }
+    },
+    "node_modules/postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postgres-bytea": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.1.tgz",
+      "integrity": "sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
+      }
+    },
+    "node_modules/ssh2": {
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/ssh2/-/ssh2-1.17.0.tgz",
+      "integrity": "sha512-wPldCk3asibAjQ/kziWQQt1Wh3PgDFpC0XpwclzKcdT1vql6KeYxf5LIt4nlFkUeR8WuphYMKqUA56X4rjbfgQ==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "asn1": "^0.2.6",
+        "bcrypt-pbkdf": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=10.16.0"
+      },
+      "optionalDependencies": {
+        "cpu-features": "~0.0.10",
+        "nan": "^2.23.0"
+      }
+    },
+    "node_modules/tweetnacl": {
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==",
+      "license": "Unlicense"
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
+      }
+    }
+  }
+}

--- a/rds-ssh-tunnel/package.json
+++ b/rds-ssh-tunnel/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "rds-ssh-tunnel",
+  "version": "1.0.0",
+  "description": "Connect to PostgreSQL databases via SSH tunnel to a bastion host, optimized for AWS RDS",
+  "type": "module",
+  "main": "src/index.ts",
+  "bin": {
+    "rds-ssh-tunnel": "./src/index.ts"
+  },
+  "scripts": {
+    "start": "node --experimental-strip-types src/index.ts"
+  },
+  "keywords": [
+    "postgresql",
+    "ssh",
+    "tunnel",
+    "rds",
+    "aws",
+    "database"
+  ],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "commander": "^12.1.0",
+    "pg": "^8.13.1",
+    "ssh2": "^1.16.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.10.2",
+    "@types/pg": "^8.11.10",
+    "@types/ssh2": "^1.15.1"
+  }
+}

--- a/rds-ssh-tunnel/src/index.ts
+++ b/rds-ssh-tunnel/src/index.ts
@@ -1,0 +1,246 @@
+#!/usr/bin/env node --experimental-strip-types
+
+import { Client } from 'ssh2';
+import { Client as PgClient } from 'pg';
+import { Command } from 'commander';
+import * as net from 'net';
+import * as fs from 'fs';
+
+interface TunnelConfig {
+    // SSH Bastion configuration
+    bastionHost: string;
+    bastionPort: number;
+    bastionUser: string;
+    bastionKeyPath?: string;
+    bastionPassword?: string;
+
+    // Database configuration
+    dbHost: string;
+    dbPort: number;
+    dbUser: string;
+    dbPassword?: string;
+    dbName: string;
+
+    // Local tunnel configuration
+    localPort: number;
+}
+
+class SSHTunnel {
+    private sshClient: Client;
+    private server: net.Server | null = null;
+    private config: TunnelConfig;
+
+    constructor(config: TunnelConfig) {
+        this.config = config;
+        this.sshClient = new Client();
+    }
+
+    async connect(): Promise<void> {
+        return new Promise((resolve, reject) => {
+            console.log(`Connecting to bastion host ${this.config.bastionUser}@${this.config.bastionHost}:${this.config.bastionPort}...`);
+
+            const sshConfig: any = {
+                host: this.config.bastionHost,
+                port: this.config.bastionPort,
+                username: this.config.bastionUser,
+            };
+
+            if (this.config.bastionKeyPath) {
+                try {
+                    sshConfig.privateKey = fs.readFileSync(this.config.bastionKeyPath);
+                } catch (error) {
+                    reject(new Error(`Failed to read SSH key from ${this.config.bastionKeyPath}: ${error}`));
+                    return;
+                }
+            } else if (this.config.bastionPassword) {
+                sshConfig.password = this.config.bastionPassword;
+            } else {
+                reject(new Error('Either bastionKeyPath or bastionPassword must be provided'));
+                return;
+            }
+
+            this.sshClient
+                .on('ready', () => {
+                    console.log('SSH connection established');
+                    this.setupTunnel();
+                    resolve();
+                })
+                .on('error', (err) => {
+                    reject(new Error(`SSH connection error: ${err.message}`));
+                })
+                .connect(sshConfig);
+        });
+    }
+
+    private setupTunnel(): void {
+        this.server = net.createServer((sock) => {
+            console.log(`New connection on local port ${this.config.localPort}`);
+
+            this.sshClient.forwardOut(
+                sock.remoteAddress!,
+                sock.remotePort!,
+                this.config.dbHost,
+                this.config.dbPort,
+                (err, stream) => {
+                    if (err) {
+                        console.error('Error forwarding connection:', err);
+                        sock.end();
+                        return;
+                    }
+
+                    sock.pipe(stream);
+                    stream.pipe(sock);
+
+                    sock.on('error', (error) => {
+                        console.error('Socket error:', error);
+                    });
+
+                    stream.on('error', (error) => {
+                        console.error('Stream error:', error);
+                    });
+                }
+            );
+        });
+
+        this.server.listen(this.config.localPort, '127.0.0.1', () => {
+            console.log(`SSH tunnel established: localhost:${this.config.localPort} -> ${this.config.dbHost}:${this.config.dbPort}`);
+        });
+    }
+
+    async close(): Promise<void> {
+        return new Promise((resolve) => {
+            if (this.server) {
+                this.server.close(() => {
+                    console.log('Tunnel server closed');
+                    this.sshClient.end();
+                    resolve();
+                });
+            } else {
+                this.sshClient.end();
+                resolve();
+            }
+        });
+    }
+}
+
+async function testDatabaseConnection(config: TunnelConfig): Promise<void> {
+    const client = new PgClient({
+        host: '127.0.0.1',
+        port: config.localPort,
+        user: config.dbUser,
+        password: config.dbPassword,
+        database: config.dbName,
+    });
+
+    try {
+        console.log('\nTesting database connection...');
+        await client.connect();
+        console.log('Successfully connected to PostgreSQL database!');
+
+        const result = await client.query('SELECT version()');
+        console.log('\nDatabase version:');
+        console.log(result.rows[0].version);
+
+        const dbResult = await client.query('SELECT current_database()');
+        console.log(`\nConnected to database: ${dbResult.rows[0].current_database}`);
+
+        await client.end();
+    } catch (error) {
+        console.error('Database connection failed:', error);
+        throw error;
+    }
+}
+
+async function main() {
+    const program = new Command();
+
+    program
+        .name('rds-ssh-tunnel')
+        .description('Connect to PostgreSQL databases via SSH tunnel to a bastion host, optimized for AWS RDS')
+        .version('1.0.0');
+
+    program
+        .option('-bh, --bastion-host <host>', 'Bastion host address')
+        .option('-bp, --bastion-port <port>', 'Bastion SSH port', '22')
+        .option('-bu, --bastion-user <user>', 'Bastion SSH username', process.env.USER || 'ec2-user')
+        .option('-bk, --bastion-key <path>', 'Path to SSH private key', `${process.env.HOME}/.ssh/id_rsa`)
+        .option('-bpw, --bastion-password <password>', 'Bastion SSH password (alternative to key)')
+        .option('-dh, --db-host <host>', 'Database host (RDS endpoint)')
+        .option('-dp, --db-port <port>', 'Database port', '5432')
+        .option('-du, --db-user <user>', 'Database username', 'postgres')
+        .option('-dpw, --db-password <password>', 'Database password')
+        .option('-dn, --db-name <name>', 'Database name', 'postgres')
+        .option('-lp, --local-port <port>', 'Local port for tunnel', '5433')
+        .option('--test', 'Test the database connection after establishing tunnel', false)
+        .option('--keep-alive', 'Keep the tunnel alive (default: exit after test)', false);
+
+    program.parse();
+
+    const options = program.opts();
+
+    // Validate required options
+    if (!options.bastionHost) {
+        console.error('Error: --bastion-host is required');
+        process.exit(1);
+    }
+
+    if (!options.dbHost) {
+        console.error('Error: --db-host is required');
+        process.exit(1);
+    }
+
+    const config: TunnelConfig = {
+        bastionHost: options.bastionHost,
+        bastionPort: parseInt(options.bastionPort),
+        bastionUser: options.bastionUser,
+        bastionKeyPath: options.bastionPassword ? undefined : options.bastionKey,
+        bastionPassword: options.bastionPassword,
+        dbHost: options.dbHost,
+        dbPort: parseInt(options.dbPort),
+        dbUser: options.dbUser,
+        dbPassword: options.dbPassword,
+        dbName: options.dbName,
+        localPort: parseInt(options.localPort),
+    };
+
+    const tunnel = new SSHTunnel(config);
+
+    // Handle graceful shutdown
+    const cleanup = async () => {
+        console.log('\n\nShutting down...');
+        await tunnel.close();
+        process.exit(0);
+    };
+
+    process.on('SIGINT', cleanup);
+    process.on('SIGTERM', cleanup);
+
+    try {
+        await tunnel.connect();
+
+        if (options.test) {
+            await testDatabaseConnection(config);
+
+            if (!options.keepAlive) {
+                console.log('\nTest complete. Use --keep-alive to keep the tunnel open.');
+                await cleanup();
+            } else {
+                console.log('\nTunnel is active. Press Ctrl+C to close.');
+                console.log(`\nConnection string: postgresql://${config.dbUser}@localhost:${config.localPort}/${config.dbName}`);
+            }
+        } else {
+            console.log('\nTunnel is active. Press Ctrl+C to close.');
+            console.log(`\nConnection string: postgresql://${config.dbUser}@localhost:${config.localPort}/${config.dbName}`);
+        }
+
+        // Keep the process alive if not testing or if keep-alive is set
+        if (!options.test || options.keepAlive) {
+            await new Promise(() => {}); // Keep alive indefinitely
+        }
+    } catch (error) {
+        console.error('Error:', error);
+        process.exit(1);
+    }
+}
+
+main();

--- a/rds-ssh-tunnel/tsconfig.json
+++ b/rds-ssh-tunnel/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2022"],
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
This new TypeScript tool provides secure database access through SSH tunnels to bastion hosts, with specific optimizations for AWS RDS.

Features:
- SSH tunnel creation using ssh2 package
- PostgreSQL connection through tunnel
- Native TypeScript execution with Node.js
- Comprehensive CLI with commander
- AWS RDS-optimized configuration
- Connection testing and keep-alive modes
- Support for both SSH key and password authentication

The tool can be used to connect to RDS databases behind bastion hosts with a simple command-line interface.