### PR TITLE
Add Rust implementation of git-dirty-checker with parallel processing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,3 +37,10 @@ All shell scripts in this repository must follow these guidelines:
 
 - Use `#!/usr/bin/env bash` as the shebang line instead of `#!/bin/bash`
   - This provides better portability across different systems where bash may be installed in different locations
+
+## Rust Projects
+
+All Rust projects in this repository must follow these guidelines:
+
+- Use `edition = "2024"` in Cargo.toml
+  - This ensures projects use the latest Rust edition with modern language features and best practices

--- a/git-dirty-checker/README.md
+++ b/git-dirty-checker/README.md
@@ -11,6 +11,7 @@ This tool helps you quickly identify which repositories in a collection of git r
 This repository contains multiple implementations of the same functionality:
 
 - **[java/](java/)** - A Java implementation that can be run as a standalone JAR
+- **[rust/](rust/)** - A Rust implementation with parallel processing for high performance
 - **[shell/](shell/)** - Shell script implementations (both sequential and parallel versions)
 
 Each implementation provides the same core functionality: given one or more directory paths, it will search for git repositories in subdirectories and report which ones have uncommitted changes.

--- a/git-dirty-checker/rust/.gitignore
+++ b/git-dirty-checker/rust/.gitignore
@@ -1,0 +1,2 @@
+/target
+Cargo.lock

--- a/git-dirty-checker/rust/Cargo.toml
+++ b/git-dirty-checker/rust/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "git-dirty-checker"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 rayon = "1.10"

--- a/git-dirty-checker/rust/Cargo.toml
+++ b/git-dirty-checker/rust/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "git-dirty-checker"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+rayon = "1.10"

--- a/git-dirty-checker/rust/README.md
+++ b/git-dirty-checker/rust/README.md
@@ -1,0 +1,38 @@
+# Rust Implementation of git-dirty-checker
+
+A parallel Rust implementation to find git repositories with uncommitted changes.
+
+## Features
+
+- **Parallel processing**: Uses Rayon to check multiple repositories concurrently for better performance
+- **Fast**: Compiled binary provides excellent performance
+- **Simple**: Minimal dependencies and straightforward implementation
+
+## Building
+
+```bash
+cargo build --release
+```
+
+The compiled binary will be available at `target/release/git-dirty-checker`.
+
+## Usage
+
+```bash
+cargo run --release -- /path/to/repos /another/path
+```
+
+Or, after building:
+
+```bash
+./target/release/git-dirty-checker /path/to/repos /another/path
+```
+
+## Output
+
+Outputs the full paths of repositories with uncommitted changes, one per line.
+
+## Requirements
+
+- Rust toolchain (cargo and rustc)
+- Git must be installed and available in PATH

--- a/git-dirty-checker/rust/src/main.rs
+++ b/git-dirty-checker/rust/src/main.rs
@@ -1,0 +1,65 @@
+use rayon::prelude::*;
+use std::env;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+
+fn main() {
+    let args: Vec<String> = env::args().skip(1).collect();
+
+    if args.is_empty() {
+        eprintln!("Usage: git-dirty-checker <directory> [<directory> ...]");
+        eprintln!("\nFinds git repositories with uncommitted changes in subdirectories.");
+        std::process::exit(1);
+    }
+
+    let repositories: Vec<PathBuf> = args
+        .par_iter()
+        .flat_map(|dir| find_subdirectories(dir))
+        .collect();
+
+    let dirty_repos: Vec<PathBuf> = repositories
+        .par_iter()
+        .filter(|repo| is_dirty_repository(repo))
+        .cloned()
+        .collect();
+
+    for repo in dirty_repos {
+        if let Ok(canonical) = fs::canonicalize(&repo) {
+            println!("{}", canonical.display());
+        }
+    }
+}
+
+fn find_subdirectories(path: &str) -> Vec<PathBuf> {
+    let dir_path = Path::new(path);
+
+    if !dir_path.is_dir() {
+        return Vec::new();
+    }
+
+    match fs::read_dir(dir_path) {
+        Ok(entries) => entries
+            .filter_map(|entry| entry.ok())
+            .filter(|entry| entry.path().is_dir())
+            .map(|entry| entry.path())
+            .collect(),
+        Err(_) => Vec::new(),
+    }
+}
+
+fn is_dirty_repository(path: &Path) -> bool {
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(path)
+        .arg("status")
+        .arg("--porcelain")
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .output();
+
+    match output {
+        Ok(output) => !output.stdout.is_empty(),
+        Err(_) => false,
+    }
+}


### PR DESCRIPTION
- Create Rust implementation in git-dirty-checker/rust
- Use Rayon for parallel processing of repositories
- Add comprehensive README with build and usage instructions
- Include .gitignore for Rust build artifacts
- Update main README to list Rust implementation