### PR TITLE
Add linear-notifications: interactive CLI for Linear unread notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,4 @@ A collection of small tools.
 | [git-repos-latest-activity](git-repos-latest-activity/) | Lists git repositories sorted by date of latest commit |
 | [log-jsonify](log-jsonify/) | Processes JSONL streams, wrapping non-JSON lines in JSON envelopes |
 | [x-java-home](x-java-home/) | A drop-in replacement for macOS java_home with JSON output support |
+| [linear-notifications](linear-notifications/) | Interactive CLI for viewing and opening unread Linear notifications |

--- a/linear-notifications/.gitignore
+++ b/linear-notifications/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+dist/

--- a/linear-notifications/README.md
+++ b/linear-notifications/README.md
@@ -5,7 +5,7 @@ Interactive CLI for viewing and opening unread [Linear](https://linear.app) noti
 ## Requirements
 
 - [Node.js](https://nodejs.org) (v18+)
-- The [`linear`](https://github.com/linear/linear) CLI, authenticated and available on your `PATH`
+- The [`linear`](https://github.com/schpet/linear-cli) CLI, authenticated and available on your `PATH`
 
 ## Installation
 

--- a/linear-notifications/README.md
+++ b/linear-notifications/README.md
@@ -1,0 +1,49 @@
+# linear-notifications
+
+Interactive CLI for viewing and opening unread [Linear](https://linear.app) notifications in the terminal.
+
+## Requirements
+
+- [Node.js](https://nodejs.org) (v18+)
+- The [`linear`](https://github.com/linear/linear) CLI, authenticated and available on your `PATH`
+
+## Installation
+
+```sh
+npm install -g .
+```
+
+This builds the TypeScript source and installs the `linear-notifications` command globally.
+
+## Usage
+
+```sh
+linear-notifications
+```
+
+If there are no unread notifications, the command exits immediately. Otherwise an inline interactive list appears:
+
+```
+Linear Notifications — 3 unread notifications
+▶ ICC-820 Expose installation report submissions as flat tables    5m ago
+  ICC-719 Update API rate limiting strategy                       2h ago
+  ICC-701 Fix authentication bug in mobile app                    1d ago
+↑↓/jk: navigate  Enter: open  r: reload  q/Esc: quit
+```
+
+### Key bindings
+
+| Key | Action |
+|-----|--------|
+| `↑` / `k` | Move selection up |
+| `↓` / `j` | Move selection down |
+| `Enter` | Open selected notification URL in the browser |
+| `r` | Reload the notification list |
+| `q` / `Esc` | Quit |
+
+## Development
+
+```sh
+npm run build   # compile TypeScript to dist/
+npm start       # run the compiled output
+```

--- a/linear-notifications/package-lock.json
+++ b/linear-notifications/package-lock.json
@@ -1,0 +1,50 @@
+{
+  "name": "linear-notifications",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "linear-notifications",
+      "version": "1.0.0",
+      "bin": {
+        "linear-notifications": "dist/index.js"
+      },
+      "devDependencies": {
+        "@types/node": "^22.0.0",
+        "typescript": "^5.0.0"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "22.19.15",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.15.tgz",
+      "integrity": "sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/linear-notifications/package.json
+++ b/linear-notifications/package.json
@@ -8,6 +8,7 @@
   },
   "scripts": {
     "build": "tsc",
+    "prepare": "npm run build",
     "start": "node dist/index.js",
     "dev": "ts-node src/index.ts"
   },

--- a/linear-notifications/package.json
+++ b/linear-notifications/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "linear-notifications",
+  "version": "1.0.0",
+  "description": "Interactive CLI for viewing unread Linear notifications",
+  "main": "dist/index.js",
+  "bin": {
+    "linear-notifications": "dist/index.js"
+  },
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/index.js",
+    "dev": "ts-node src/index.ts"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "typescript": "^5.0.0"
+  }
+}

--- a/linear-notifications/src/index.ts
+++ b/linear-notifications/src/index.ts
@@ -1,0 +1,283 @@
+#!/usr/bin/env node
+
+import { execSync, spawnSync } from "child_process";
+import * as readline from "readline";
+
+const GRAPHQL_QUERY = `query {
+  notifications(first: 50) {
+    nodes {
+      id
+      type
+      title
+      subtitle
+      createdAt
+      readAt
+      url
+      actor { name }
+      ... on IssueNotification {
+        issue { identifier title }
+        comment { body }
+      }
+      ... on ProjectNotification {
+        project { name }
+        comment { body }
+      }
+      ... on PullRequestNotification {
+        pullRequest { title number url }
+      }
+      ... on DocumentNotification {
+        documentId
+      }
+    }
+  }
+}`;
+
+interface Notification {
+  id: string;
+  type: string;
+  title: string;
+  subtitle: string | null;
+  createdAt: string;
+  readAt: string | null;
+  url: string;
+  actor: { name: string } | null;
+}
+
+function fetchUnreadNotifications(): Notification[] {
+  const result = spawnSync("linear", ["api", GRAPHQL_QUERY], {
+    encoding: "utf8",
+  });
+
+  if (result.error) {
+    throw new Error(`Failed to run linear CLI: ${result.error.message}`);
+  }
+  if (result.status !== 0) {
+    throw new Error(`linear CLI exited with code ${result.status}: ${result.stderr}`);
+  }
+
+  const data = JSON.parse(result.stdout);
+  const nodes: Notification[] = data?.data?.notifications?.nodes ?? [];
+  return nodes.filter((n) => n.readAt === null);
+}
+
+function openUrl(url: string): void {
+  const platform = process.platform;
+  const cmd = platform === "darwin" ? "open" : platform === "win32" ? "start" : "xdg-open";
+  spawnSync(cmd, [url], { stdio: "inherit" });
+}
+
+function formatTime(iso: string): string {
+  const date = new Date(iso);
+  const now = new Date();
+  const diffMs = now.getTime() - date.getTime();
+  const diffMins = Math.floor(diffMs / 60000);
+  if (diffMins < 60) return `${diffMins}m ago`;
+  const diffHours = Math.floor(diffMins / 60);
+  if (diffHours < 24) return `${diffHours}h ago`;
+  const diffDays = Math.floor(diffHours / 24);
+  return `${diffDays}d ago`;
+}
+
+function truncate(str: string, maxLen: number): string {
+  if (str.length <= maxLen) return str;
+  return str.slice(0, maxLen - 1) + "…";
+}
+
+// ANSI escape helpers
+const ESC = "\x1b";
+const CLEAR_SCREEN = `${ESC}[2J${ESC}[H`;
+const HIDE_CURSOR = `${ESC}[?25l`;
+const SHOW_CURSOR = `${ESC}[?25h`;
+const RESET = `${ESC}[0m`;
+const BOLD = `${ESC}[1m`;
+const DIM = `${ESC}[2m`;
+const REVERSE = `${ESC}[7m`;
+const CYAN = `${ESC}[36m`;
+const YELLOW = `${ESC}[33m`;
+const GREEN = `${ESC}[32m`;
+
+function moveTo(row: number, col: number): string {
+  return `${ESC}[${row};${col}H`;
+}
+
+function render(notifications: Notification[], selected: number, statusMsg: string): void {
+  const { rows, columns } = process.stdout;
+  const termRows = rows ?? 24;
+  const termCols = columns ?? 80;
+
+  let out = CLEAR_SCREEN;
+
+  // Header
+  out += moveTo(1, 1);
+  out += BOLD + CYAN;
+  out += truncate("Linear Unread Notifications", termCols);
+  out += RESET;
+
+  // Status line (row 2)
+  out += moveTo(2, 1);
+  out += DIM;
+  out += truncate(statusMsg, termCols);
+  out += RESET;
+
+  // Separator
+  out += moveTo(3, 1);
+  out += DIM + "─".repeat(termCols) + RESET;
+
+  // List area: rows 4 to termRows-2
+  const listTop = 4;
+  const listBottom = termRows - 2;
+  const listHeight = listBottom - listTop + 1;
+
+  // Scroll offset to keep selected item visible
+  const scrollOffset = Math.max(0, selected - listHeight + 1);
+
+  for (let i = 0; i < listHeight; i++) {
+    const idx = i + scrollOffset;
+    out += moveTo(listTop + i, 1);
+
+    if (idx >= notifications.length) {
+      out += " ".repeat(termCols);
+      continue;
+    }
+
+    const n = notifications[idx];
+    const isSelected = idx === selected;
+    const timeStr = formatTime(n.createdAt);
+    const timeWidth = 8;
+    const titleWidth = termCols - timeWidth - 2;
+
+    const title = truncate(n.title, titleWidth);
+    const time = timeStr.padStart(timeWidth);
+
+    const line = ` ${title.padEnd(titleWidth)} ${time}`;
+
+    if (isSelected) {
+      out += REVERSE + BOLD;
+      out += truncate(line, termCols).padEnd(termCols);
+      out += RESET;
+    } else {
+      out += line;
+    }
+  }
+
+  // Bottom separator
+  out += moveTo(termRows - 1, 1);
+  out += DIM + "─".repeat(termCols) + RESET;
+
+  // Help line
+  out += moveTo(termRows, 1);
+  out += DIM;
+  out += truncate("Enter: open  r: reload  q/Esc: quit", termCols);
+  out += RESET;
+
+  process.stdout.write(out);
+}
+
+async function main(): Promise<void> {
+  let notifications: Notification[];
+
+  try {
+    notifications = fetchUnreadNotifications();
+  } catch (err) {
+    process.stderr.write(`Error fetching notifications: ${err}\n`);
+    process.exit(1);
+  }
+
+  if (notifications.length === 0) {
+    process.stdout.write("No unread notifications.\n");
+    process.exit(0);
+  }
+
+  // Enter raw mode
+  const stdin = process.stdin;
+  stdin.setRawMode(true);
+  stdin.resume();
+  stdin.setEncoding("utf8");
+
+  process.stdout.write(HIDE_CURSOR);
+
+  let selected = 0;
+  let statusMsg = `${notifications.length} unread notification${notifications.length !== 1 ? "s" : ""}`;
+
+  function redraw(): void {
+    render(notifications, selected, statusMsg);
+  }
+
+  function exit(): void {
+    process.stdout.write(SHOW_CURSOR + CLEAR_SCREEN);
+    stdin.setRawMode(false);
+    process.exit(0);
+  }
+
+  redraw();
+
+  process.stdout.on("resize", () => {
+    redraw();
+  });
+
+  stdin.on("data", (key: string) => {
+    // Ctrl-C
+    if (key === "\x03") {
+      exit();
+      return;
+    }
+
+    // q or Escape
+    if (key === "q" || key === "\x1b") {
+      exit();
+      return;
+    }
+
+    // r - reload
+    if (key === "r") {
+      statusMsg = "Reloading…";
+      redraw();
+      try {
+        notifications = fetchUnreadNotifications();
+        if (notifications.length === 0) {
+          process.stdout.write(SHOW_CURSOR + CLEAR_SCREEN);
+          stdin.setRawMode(false);
+          process.stdout.write("No unread notifications.\n");
+          process.exit(0);
+        }
+        selected = Math.min(selected, notifications.length - 1);
+        statusMsg = `${notifications.length} unread notification${notifications.length !== 1 ? "s" : ""}`;
+      } catch (err) {
+        statusMsg = `Error: ${err}`;
+      }
+      redraw();
+      return;
+    }
+
+    // Arrow up / k
+    if (key === "\x1b[A" || key === "k") {
+      selected = Math.max(0, selected - 1);
+      redraw();
+      return;
+    }
+
+    // Arrow down / j
+    if (key === "\x1b[B" || key === "j") {
+      selected = Math.min(notifications.length - 1, selected + 1);
+      redraw();
+      return;
+    }
+
+    // Enter
+    if (key === "\r" || key === "\n") {
+      const n = notifications[selected];
+      if (n?.url) {
+        process.stdout.write(SHOW_CURSOR + CLEAR_SCREEN);
+        stdin.setRawMode(false);
+        openUrl(n.url);
+        process.exit(0);
+      }
+      return;
+    }
+  });
+}
+
+main().catch((err) => {
+  process.stderr.write(`Fatal error: ${err}\n`);
+  process.exit(1);
+});

--- a/linear-notifications/src/index.ts
+++ b/linear-notifications/src/index.ts
@@ -1,7 +1,6 @@
 #!/usr/bin/env node
 
-import { execSync, spawnSync } from "child_process";
-import * as readline from "readline";
+import { spawnSync } from "child_process";
 
 const GRAPHQL_QUERY = `query {
   notifications(first: 50) {
@@ -52,7 +51,9 @@ function fetchUnreadNotifications(): Notification[] {
     throw new Error(`Failed to run linear CLI: ${result.error.message}`);
   }
   if (result.status !== 0) {
-    throw new Error(`linear CLI exited with code ${result.status}: ${result.stderr}`);
+    throw new Error(
+      `linear CLI exited with code ${result.status}: ${result.stderr}`
+    );
   }
 
   const data = JSON.parse(result.stdout);
@@ -62,7 +63,8 @@ function fetchUnreadNotifications(): Notification[] {
 
 function openUrl(url: string): void {
   const platform = process.platform;
-  const cmd = platform === "darwin" ? "open" : platform === "win32" ? "start" : "xdg-open";
+  const cmd =
+    platform === "darwin" ? "open" : platform === "win32" ? "start" : "xdg-open";
   spawnSync(cmd, [url], { stdio: "inherit" });
 }
 
@@ -79,13 +81,13 @@ function formatTime(iso: string): string {
 }
 
 function truncate(str: string, maxLen: number): string {
+  if (maxLen <= 0) return "";
   if (str.length <= maxLen) return str;
   return str.slice(0, maxLen - 1) + "…";
 }
 
 // ANSI escape helpers
 const ESC = "\x1b";
-const CLEAR_SCREEN = `${ESC}[2J${ESC}[H`;
 const HIDE_CURSOR = `${ESC}[?25l`;
 const SHOW_CURSOR = `${ESC}[?25h`;
 const RESET = `${ESC}[0m`;
@@ -93,84 +95,106 @@ const BOLD = `${ESC}[1m`;
 const DIM = `${ESC}[2m`;
 const REVERSE = `${ESC}[7m`;
 const CYAN = `${ESC}[36m`;
-const YELLOW = `${ESC}[33m`;
-const GREEN = `${ESC}[32m`;
+const CLEAR_LINE = `${ESC}[2K`;
+const UP = (n: number) => `${ESC}[${n}A`;
 
-function moveTo(row: number, col: number): string {
-  return `${ESC}[${row};${col}H`;
+const MAX_VISIBLE_ITEMS = 10;
+
+// The inline rendering area has a fixed height determined at startup:
+//   1 header line + visibleItems lines + 1 help line
+let areaHeight = 0;
+let scrollOffset = 0;
+
+function computeVisibleItems(count: number): number {
+  return Math.min(count, MAX_VISIBLE_ITEMS);
 }
 
-function render(notifications: Notification[], selected: number, statusMsg: string): void {
-  const { rows, columns } = process.stdout;
-  const termRows = rows ?? 24;
-  const termCols = columns ?? 80;
+/** Reserve `areaHeight` blank lines below current cursor, then move back up. */
+function reserveArea(height: number): void {
+  areaHeight = height;
+  // Move cursor down by printing newlines (may scroll terminal), then back up
+  process.stdout.write("\n".repeat(height) + UP(height));
+}
 
-  let out = CLEAR_SCREEN;
+/**
+ * Render the entire inline area in-place.
+ * After rendering, cursor is left at the top-left of the area so the next
+ * render also starts there.
+ */
+function render(
+  notifications: Notification[],
+  selected: number,
+  statusMsg: string
+): void {
+  const termCols = process.stdout.columns ?? 80;
+  const visibleItems = computeVisibleItems(notifications.length);
 
-  // Header
-  out += moveTo(1, 1);
-  out += BOLD + CYAN;
-  out += truncate("Linear Unread Notifications", termCols);
-  out += RESET;
+  // Adjust scroll to keep selected in view
+  if (selected < scrollOffset) {
+    scrollOffset = selected;
+  } else if (selected >= scrollOffset + visibleItems) {
+    scrollOffset = selected - visibleItems + 1;
+  }
 
-  // Status line (row 2)
-  out += moveTo(2, 1);
-  out += DIM;
-  out += truncate(statusMsg, termCols);
-  out += RESET;
+  let out = "\r"; // go to column 1
 
-  // Separator
-  out += moveTo(3, 1);
-  out += DIM + "─".repeat(termCols) + RESET;
+  // ── Header ──────────────────────────────────────────────────────────────
+  out += CLEAR_LINE;
+  const headerText = `${BOLD}${CYAN}Linear Notifications${RESET} ${DIM}— ${statusMsg}${RESET}`;
+  out += headerText + "\n";
 
-  // List area: rows 4 to termRows-2
-  const listTop = 4;
-  const listBottom = termRows - 2;
-  const listHeight = listBottom - listTop + 1;
-
-  // Scroll offset to keep selected item visible
-  const scrollOffset = Math.max(0, selected - listHeight + 1);
-
-  for (let i = 0; i < listHeight; i++) {
+  // ── Item lines ───────────────────────────────────────────────────────────
+  for (let i = 0; i < visibleItems; i++) {
+    out += CLEAR_LINE;
     const idx = i + scrollOffset;
-    out += moveTo(listTop + i, 1);
-
-    if (idx >= notifications.length) {
-      out += " ".repeat(termCols);
-      continue;
-    }
-
     const n = notifications[idx];
     const isSelected = idx === selected;
+
     const timeStr = formatTime(n.createdAt);
     const timeWidth = 8;
-    const titleWidth = termCols - timeWidth - 2;
-
+    const prefix = isSelected ? "▶ " : "  ";
+    const titleWidth = Math.max(0, termCols - timeWidth - prefix.length - 1);
     const title = truncate(n.title, titleWidth);
     const time = timeStr.padStart(timeWidth);
-
-    const line = ` ${title.padEnd(titleWidth)} ${time}`;
+    const line = `${prefix}${title.padEnd(titleWidth)} ${time}`;
 
     if (isSelected) {
-      out += REVERSE + BOLD;
-      out += truncate(line, termCols).padEnd(termCols);
-      out += RESET;
+      out += REVERSE + BOLD + truncate(line, termCols).padEnd(termCols) + RESET;
     } else {
       out += line;
     }
+    out += "\n";
   }
 
-  // Bottom separator
-  out += moveTo(termRows - 1, 1);
-  out += DIM + "─".repeat(termCols) + RESET;
+  // ── Help line ────────────────────────────────────────────────────────────
+  out += CLEAR_LINE;
+  out += DIM + "↑↓/jk: navigate  Enter: open  r: reload  q/Esc: quit" + RESET;
 
-  // Help line
-  out += moveTo(termRows, 1);
-  out += DIM;
-  out += truncate("Enter: open  r: reload  q/Esc: quit", termCols);
-  out += RESET;
+  // Move cursor back to the top of the area for the next render
+  out += UP(areaHeight - 1) + "\r";
 
   process.stdout.write(out);
+}
+
+/** Clear all lines in the reserved area and leave cursor at the top. */
+function clearArea(): void {
+  let out = "\r";
+  for (let i = 0; i < areaHeight; i++) {
+    out += CLEAR_LINE;
+    if (i < areaHeight - 1) out += "\n";
+  }
+  if (areaHeight > 1) {
+    out += UP(areaHeight - 1);
+  }
+  out += "\r";
+  process.stdout.write(out);
+}
+
+function exit(stdin: NodeJS.ReadStream): void {
+  clearArea();
+  process.stdout.write(SHOW_CURSOR);
+  stdin.setRawMode(false);
+  process.exit(0);
 }
 
 async function main(): Promise<void> {
@@ -188,7 +212,6 @@ async function main(): Promise<void> {
     process.exit(0);
   }
 
-  // Enter raw mode
   const stdin = process.stdin;
   stdin.setRawMode(true);
   stdin.resume();
@@ -199,43 +222,36 @@ async function main(): Promise<void> {
   let selected = 0;
   let statusMsg = `${notifications.length} unread notification${notifications.length !== 1 ? "s" : ""}`;
 
-  function redraw(): void {
-    render(notifications, selected, statusMsg);
-  }
-
-  function exit(): void {
-    process.stdout.write(SHOW_CURSOR + CLEAR_SCREEN);
-    stdin.setRawMode(false);
-    process.exit(0);
-  }
-
-  redraw();
+  const visibleItems = computeVisibleItems(notifications.length);
+  reserveArea(visibleItems + 2); // header + items + help
+  render(notifications, selected, statusMsg);
 
   process.stdout.on("resize", () => {
-    redraw();
+    render(notifications, selected, statusMsg);
   });
 
   stdin.on("data", (key: string) => {
     // Ctrl-C
     if (key === "\x03") {
-      exit();
+      exit(stdin);
       return;
     }
 
     // q or Escape
     if (key === "q" || key === "\x1b") {
-      exit();
+      exit(stdin);
       return;
     }
 
     // r - reload
     if (key === "r") {
       statusMsg = "Reloading…";
-      redraw();
+      render(notifications, selected, statusMsg);
       try {
         notifications = fetchUnreadNotifications();
         if (notifications.length === 0) {
-          process.stdout.write(SHOW_CURSOR + CLEAR_SCREEN);
+          clearArea();
+          process.stdout.write(SHOW_CURSOR);
           stdin.setRawMode(false);
           process.stdout.write("No unread notifications.\n");
           process.exit(0);
@@ -243,23 +259,23 @@ async function main(): Promise<void> {
         selected = Math.min(selected, notifications.length - 1);
         statusMsg = `${notifications.length} unread notification${notifications.length !== 1 ? "s" : ""}`;
       } catch (err) {
-        statusMsg = `Error: ${err}`;
+        statusMsg = `Error reloading: ${err}`;
       }
-      redraw();
+      render(notifications, selected, statusMsg);
       return;
     }
 
     // Arrow up / k
     if (key === "\x1b[A" || key === "k") {
       selected = Math.max(0, selected - 1);
-      redraw();
+      render(notifications, selected, statusMsg);
       return;
     }
 
     // Arrow down / j
     if (key === "\x1b[B" || key === "j") {
       selected = Math.min(notifications.length - 1, selected + 1);
-      redraw();
+      render(notifications, selected, statusMsg);
       return;
     }
 
@@ -267,7 +283,8 @@ async function main(): Promise<void> {
     if (key === "\r" || key === "\n") {
       const n = notifications[selected];
       if (n?.url) {
-        process.stdout.write(SHOW_CURSOR + CLEAR_SCREEN);
+        clearArea();
+        process.stdout.write(SHOW_CURSOR);
         stdin.setRawMode(false);
         openUrl(n.url);
         process.exit(0);

--- a/linear-notifications/tsconfig.json
+++ b/linear-notifications/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "commonjs",
+    "lib": ["ES2022"],
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Summary
Introduces a new interactive CLI tool for browsing and opening unread Linear notifications directly from the terminal.

## Key Changes
- **New package**: `linear-notifications/` with TypeScript source and build configuration
- **Interactive TUI**: Terminal-based interface for viewing unread notifications with:
  - Scrollable list of notifications with timestamps
  - Keyboard navigation (arrow keys, vim-style j/k, Enter to open)
  - Real-time reload capability (r key)
  - Responsive layout that adapts to terminal size
- **Linear API integration**: Fetches notifications via Linear CLI's GraphQL API
- **Cross-platform support**: Opens URLs using platform-appropriate commands (open/start/xdg-open)
- **Build setup**: TypeScript configuration, npm scripts for build/dev, and proper .gitignore

## Implementation Details
- Uses ANSI escape codes for terminal rendering (colors, cursor control, screen clearing)
- Implements scroll offset calculation to keep selected item visible
- Gracefully handles edge cases (no notifications, terminal resize, API errors)
- Raw mode input handling for responsive keyboard interaction
- Relative time formatting (e.g., "5m ago", "2h ago") for notification timestamps

https://claude.ai/code/session_013y4gtTTMZiuu3pous6rjV8