### PR TITLE
Add CLI argument parsing library comparison project

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,6 +38,19 @@ All shell scripts in this repository must follow these guidelines:
 - Use `#!/usr/bin/env bash` as the shebang line instead of `#!/bin/bash`
   - This provides better portability across different systems where bash may be installed in different locations
 
+## Node.js Programs
+
+All Node.js/TypeScript projects in this repository must follow these guidelines:
+
+- Use **pnpm** as the package manager
+- Set a `minimumReleaseAge` of `"3 days"` in the Renovate configuration inside `package.json`:
+  ```json
+  "renovate": {
+    "minimumReleaseAge": "3 days"
+  }
+  ```
+  This prevents Renovate from raising PRs for dependencies that were released fewer than three days ago, reducing the risk of picking up broken or immediately-yanked releases.
+
 ## Rust Projects
 
 All Rust projects in this repository must follow these guidelines:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,13 +43,12 @@ All shell scripts in this repository must follow these guidelines:
 All Node.js/TypeScript projects in this repository must follow these guidelines:
 
 - Use **pnpm** as the package manager
-- Set a `minimumReleaseAge` of `"3 days"` in the Renovate configuration inside `package.json`:
-  ```json
-  "renovate": {
-    "minimumReleaseAge": "3 days"
-  }
+- Set `minimumReleaseAge: 4320` in `pnpm-workspace.yaml` (4320 minutes = 3 days):
+  ```yaml
+  minimumReleaseAge: 4320
   ```
-  This prevents Renovate from raising PRs for dependencies that were released fewer than three days ago, reducing the risk of picking up broken or immediately-yanked releases.
+  This is a pnpm supply-chain security feature that prevents installing package versions
+  published fewer than 3 days ago, giving the community time to detect and pull compromised releases.
 
 ## Rust Projects
 

--- a/README.md
+++ b/README.md
@@ -9,4 +9,5 @@ A collection of small tools.
 | [git-dirty-checker](git-dirty-checker/) | Checks git repositories for uncommitted changes |
 | [git-repos-latest-activity](git-repos-latest-activity/) | Lists git repositories sorted by date of latest commit |
 | [log-jsonify](log-jsonify/) | Processes JSONL streams, wrapping non-JSON lines in JSON envelopes |
+| [typescript-cli-arguments](typescript-cli-arguments/) | Side-by-side comparison of CLI argument parsing libraries for Node.js/TypeScript |
 | [x-java-home](x-java-home/) | A drop-in replacement for macOS java_home with JSON output support |

--- a/typescript-cli-arguments/.gitignore
+++ b/typescript-cli-arguments/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/typescript-cli-arguments/README.md
+++ b/typescript-cli-arguments/README.md
@@ -28,28 +28,29 @@ pnpm run commander -- greet Alice --times 3 --shout
 pnpm run yargs    -- farewell Bob --formal
 pnpm run meow     -- greet Alice --times 2
 pnpm run citty    -- farewell Bob
+pnpm run gunshi   -- greet Alice --times 2
 ```
 
 ## Comparison
 
-| Feature | [commander](https://github.com/tj/commander.js) | [yargs](https://yargs.js.org) | [meow](https://github.com/sindresorhus/meow) | [citty](https://github.com/unjs/citty) |
-|---|---|---|---|---|
-| **Package size** (self, excl. deps) | 198 KB | 337 KB | 420 KB | 48 KB |
-| **Direct dependencies** | 0 | 7 | 0 | 1 (`consola`) |
-| **TypeScript** | Bundled types | `@types/yargs` | Bundled types | Written in TS, inferred arg types |
-| **ESM** | ✓ | ✓ | ✓ (only) | ✓ |
-| **CJS** | ✓ | ✓ | ✗ | ✓ |
-| **Subcommands** | Native | Native | Manual dispatch | Native |
-| **Nested subcommands** | ✓ | ✓ | Manual | ✓ |
-| **Positional arguments** | `<required>` / `[optional]` in signature | `.positional()` builder | `cli.input` array | `type: 'positional'` |
-| **Option types** | string, boolean, int, float, custom | string, boolean, number, array, count | string, boolean, number, string\[\] | string, boolean |
-| **Required options** | ✓ | ✓ | ✓ (`isRequired`) | ✓ |
-| **Default values** | ✓ | ✓ | ✓ | ✓ |
-| **Auto-generated help** | ✓ | ✓ | ✓ (free-form text) | ✓ |
-| **Version flag** | ✓ | ✓ | ✓ (from `package.json`) | ✓ |
-| **Async action handlers** | ✓ (`.parseAsync()`) | ✓ | N/A | ✓ |
-| **Shell completion** | ✗ | ✓ bash/zsh/fish | ✗ | ✗ |
-| **Node.js requirement** | ≥ 18 | ≥ 12 | ≥ 18 | ≥ 18 |
+| Feature | [commander](https://github.com/tj/commander.js) | [yargs](https://yargs.js.org) | [meow](https://github.com/sindresorhus/meow) | [citty](https://github.com/unjs/citty) | [gunshi](https://github.com/kazupon/gunshi) |
+|---|---|---|---|---|---|
+| **Package size** (self, excl. deps) | 198 KB | 337 KB | 420 KB | 48 KB | 211 KB |
+| **Direct dependencies** | 0 | 7 | 0 | 1 (`consola`) | 0 (bundled) |
+| **TypeScript** | Bundled types | `@types/yargs` | Bundled types | Written in TS, inferred arg types | Written in TS, inferred arg types |
+| **ESM** | ✓ | ✓ | ✓ (only) | ✓ | ✓ |
+| **CJS** | ✓ | ✓ | ✗ | ✓ | ✓ |
+| **Subcommands** | Native | Native | Manual dispatch | Native | Native |
+| **Nested subcommands** | ✓ | ✓ | Manual | ✓ | ✓ |
+| **Positional arguments** | `<required>` / `[optional]` in signature | `.positional()` builder | `cli.input` array | `type: 'positional'` | `type: 'positional'` |
+| **Option types** | string, boolean, int, float, custom | string, boolean, number, array, count | string, boolean, number, string\[\] | string, boolean | string, boolean, number, positional |
+| **Required options** | ✓ | ✓ | ✓ (`isRequired`) | ✓ | ✓ |
+| **Default values** | ✓ | ✓ | ✓ | ✓ | ✓ |
+| **Auto-generated help** | ✓ | ✓ | ✓ (free-form text) | ✓ | ✓ |
+| **Version flag** | ✓ | ✓ | ✓ (from `package.json`) | ✓ | ✓ |
+| **Async action handlers** | ✓ (`.parseAsync()`) | ✓ | N/A | ✓ | ✓ |
+| **Shell completion** | ✗ | ✓ bash/zsh/fish | ✗ | ✗ | Via plugin (WIP) |
+| **Node.js requirement** | ≥ 18 | ≥ 12 | ≥ 18 | ≥ 18 | ≥ 20 |
 
 ### Notes
 
@@ -60,6 +61,8 @@ pnpm run citty    -- farewell Bob
 **meow** — Minimal and intentionally simple; designed for single-command CLIs. Subcommands require manual dispatch (inspect `cli.input[0]` and branch). ESM-only. Suitable for small tools where you want total control with minimal abstraction.
 
 **citty** — Modern, lightweight (smallest package), written in TypeScript. Offers the best type inference: arg shapes defined in `args` flow through automatically to the `run` function, with no need for manual type annotations. Subcommands declared as plain objects via `subCommands`. CJS and ESM.
+
+**gunshi** — A newer, declarative library with a `define()` + `cli()` API. Like citty, it is written in TypeScript and infers arg types directly from the definition. Supports named positional arguments (`type: 'positional'`) alongside regular options. Has an extensible plugin system; a shell completion plugin (`@gunshi/plugin-completion`) is in progress. Requires Node.js ≥ 20.
 
 ## Shell completions
 

--- a/typescript-cli-arguments/README.md
+++ b/typescript-cli-arguments/README.md
@@ -49,7 +49,7 @@ pnpm run gunshi   -- greet Alice --times 2
 | **Auto-generated help** | ✓ | ✓ | ✓ (free-form text) | ✓ | ✓ |
 | **Version flag** | ✓ | ✓ | ✓ (from `package.json`) | ✓ | ✓ |
 | **Async action handlers** | ✓ (`.parseAsync()`) | ✓ | N/A | ✓ | ✓ |
-| **Shell completion** | ✗ | ✓ bash/zsh/fish | ✗ | ✗ | Via plugin (WIP) |
+| **Shell completion** | ✗ | ✓ bash/zsh/fish | ✗ | ✗ | ✓ bash/zsh/fish/powershell (plugin) |
 | **Node.js requirement** | ≥ 18 | ≥ 12 | ≥ 18 | ≥ 18 | ≥ 20 |
 
 ### Notes
@@ -62,7 +62,7 @@ pnpm run gunshi   -- greet Alice --times 2
 
 **citty** — Modern, lightweight (smallest package), written in TypeScript. Offers the best type inference: arg shapes defined in `args` flow through automatically to the `run` function, with no need for manual type annotations. Subcommands declared as plain objects via `subCommands`. CJS and ESM.
 
-**gunshi** — A newer, declarative library with a `define()` + `cli()` API. Like citty, it is written in TypeScript and infers arg types directly from the definition. Supports named positional arguments (`type: 'positional'`) alongside regular options. Has an extensible plugin system; a shell completion plugin (`@gunshi/plugin-completion`) is in progress. Requires Node.js ≥ 20.
+**gunshi** — A newer, declarative library with a `define()` + `cli()` API. Like citty, it is written in TypeScript and infers arg types directly from the definition. Supports named positional arguments (`type: 'positional'`) alongside regular options. Has an extensible plugin system; shell completion (bash/zsh/fish/PowerShell) is provided by `@gunshi/plugin-completion`, passed as a plugin to `cli()`. Requires Node.js ≥ 20.
 
 ## Shell completions
 
@@ -83,3 +83,13 @@ pnpm --silent run yargs -- completion >> ~/.zshrc
 ```
 
 The generated script calls the program with `--get-yargs-completions` to dynamically suggest completions for commands and options.
+
+**gunshi** also has completion support, via the `@gunshi/plugin-completion` plugin (bash, zsh, fish, PowerShell):
+
+```bash
+# Print the completion script
+pnpm --silent run gunshi -- complete bash
+
+# Activate completions in the current shell session
+source <(pnpm --silent run gunshi -- complete bash)
+```

--- a/typescript-cli-arguments/README.md
+++ b/typescript-cli-arguments/README.md
@@ -1,0 +1,82 @@
+# TypeScript CLI Argument Parsing Libraries
+
+A side-by-side comparison of popular CLI argument parsing libraries for Node.js/TypeScript. Each library implements the same demo program so the differences in API style, type safety, and features are easy to compare.
+
+## The demo CLI
+
+Each file under `src/` implements a `greet-demo` program with two subcommands:
+
+```
+greet-demo greet <name> [--times <n>] [--shout]
+greet-demo farewell <name> [--formal]
+```
+
+| Argument / option | Type | Default | Description |
+|---|---|---|---|
+| `greet <name>` | positional, required | — | Name to greet |
+| `--times, -t` | number | `1` | How many times to repeat |
+| `--shout, -s` | boolean | `false` | Output in uppercase |
+| `farewell <name>` | positional, required | — | Name to address |
+| `--formal, -f` | boolean | `false` | Use formal language |
+
+## Running the examples
+
+```bash
+pnpm install
+
+pnpm run commander -- greet Alice --times 3 --shout
+pnpm run yargs    -- farewell Bob --formal
+pnpm run meow     -- greet Alice --times 2
+pnpm run citty    -- farewell Bob
+```
+
+## Comparison
+
+| Feature | [commander](https://github.com/tj/commander.js) | [yargs](https://yargs.js.org) | [meow](https://github.com/sindresorhus/meow) | [citty](https://github.com/unjs/citty) |
+|---|---|---|---|---|
+| **Package size** (self, excl. deps) | 198 KB | 337 KB | 420 KB | 48 KB |
+| **Direct dependencies** | 0 | 7 | 0 | 1 (`consola`) |
+| **TypeScript** | Bundled types | `@types/yargs` | Bundled types | Written in TS, inferred arg types |
+| **ESM** | ✓ | ✓ | ✓ (only) | ✓ |
+| **CJS** | ✓ | ✓ | ✗ | ✓ |
+| **Subcommands** | Native | Native | Manual dispatch | Native |
+| **Nested subcommands** | ✓ | ✓ | Manual | ✓ |
+| **Positional arguments** | `<required>` / `[optional]` in signature | `.positional()` builder | `cli.input` array | `type: 'positional'` |
+| **Option types** | string, boolean, int, float, custom | string, boolean, number, array, count | string, boolean, number, string\[\] | string, boolean |
+| **Required options** | ✓ | ✓ | ✓ (`isRequired`) | ✓ |
+| **Default values** | ✓ | ✓ | ✓ | ✓ |
+| **Auto-generated help** | ✓ | ✓ | ✓ (free-form text) | ✓ |
+| **Version flag** | ✓ | ✓ | ✓ (from `package.json`) | ✓ |
+| **Async action handlers** | ✓ (`.parseAsync()`) | ✓ | N/A | ✓ |
+| **Shell completion** | ✗ | ✓ bash/zsh/fish | ✗ | ✗ |
+| **Node.js requirement** | ≥ 18 | ≥ 12 | ≥ 18 | ≥ 18 |
+
+### Notes
+
+**commander** — The most widely used CLI library. Zero dependencies, ships dual ESM/CJS, bundled types. Subcommand syntax uses a natural string signature (`"greet <name>"`). No built-in shell completion; third-party packages like [`omelette`](https://github.com/arturadib/omelette) can add it.
+
+**yargs** — Feature-rich with a fluent builder API. The only library here with built-in shell completion (bash/zsh/fish). Has more option types than the others (arrays, count). The `@types/yargs` package provides TypeScript types; inference from builder calls is decent but not as tight as citty.
+
+**meow** — Minimal and intentionally simple; designed for single-command CLIs. Subcommands require manual dispatch (inspect `cli.input[0]` and branch). ESM-only. Suitable for small tools where you want total control with minimal abstraction.
+
+**citty** — Modern, lightweight (smallest package), written in TypeScript. Offers the best type inference: arg shapes defined in `args` flow through automatically to the `run` function, with no need for manual type annotations. Subcommands declared as plain objects via `subCommands`. CJS and ESM.
+
+## Shell completions
+
+Only **yargs** has built-in shell completion support. The `.completion()` call adds a `completion` subcommand that outputs a bash/zsh completion script:
+
+```bash
+# Print the completion script
+pnpm --silent run yargs -- completion
+
+# Activate completions in the current shell session
+source <(pnpm --silent run yargs -- completion)
+
+# Install permanently (bash)
+pnpm --silent run yargs -- completion >> ~/.bash_completion
+
+# Install permanently (zsh — add before compinit)
+pnpm --silent run yargs -- completion >> ~/.zshrc
+```
+
+The generated script calls the program with `--get-yargs-completions` to dynamically suggest completions for commands and options.

--- a/typescript-cli-arguments/package.json
+++ b/typescript-cli-arguments/package.json
@@ -21,6 +21,9 @@
     "typescript": "^5.4.5"
   },
   "pnpm": {
-    "onlyBuiltDependencies": ["esbuild"]
+    "ignoredBuiltDependencies": ["esbuild"]
+  },
+  "renovate": {
+    "minimumReleaseAge": "3 days"
   }
 }

--- a/typescript-cli-arguments/package.json
+++ b/typescript-cli-arguments/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "typescript-cli-arguments",
+  "version": "1.0.0",
+  "description": "Comparison of CLI argument parsing libraries for Node.js/TypeScript",
+  "type": "module",
+  "scripts": {
+    "commander": "tsx src/commander.ts",
+    "yargs": "tsx src/yargs.ts",
+    "meow": "tsx src/meow.ts",
+    "citty": "tsx src/citty.ts"
+  },
+  "dependencies": {
+    "citty": "^0.1.6",
+    "commander": "^12.0.0",
+    "meow": "^13.2.0",
+    "yargs": "^17.7.2"
+  },
+  "devDependencies": {
+    "@types/yargs": "^17.0.32",
+    "tsx": "^4.19.0",
+    "typescript": "^5.4.5"
+  },
+  "pnpm": {
+    "onlyBuiltDependencies": ["esbuild"]
+  }
+}

--- a/typescript-cli-arguments/package.json
+++ b/typescript-cli-arguments/package.json
@@ -7,11 +7,13 @@
     "commander": "tsx src/commander.ts",
     "yargs": "tsx src/yargs.ts",
     "meow": "tsx src/meow.ts",
-    "citty": "tsx src/citty.ts"
+    "citty": "tsx src/citty.ts",
+    "gunshi": "tsx src/gunshi.ts"
   },
   "dependencies": {
     "citty": "^0.1.6",
     "commander": "^12.0.0",
+    "gunshi": "^0.29.0",
     "meow": "^13.2.0",
     "yargs": "^17.7.2"
   },
@@ -22,8 +24,5 @@
   },
   "pnpm": {
     "ignoredBuiltDependencies": ["esbuild"]
-  },
-  "renovate": {
-    "minimumReleaseAge": "3 days"
   }
 }

--- a/typescript-cli-arguments/package.json
+++ b/typescript-cli-arguments/package.json
@@ -11,6 +11,7 @@
     "gunshi": "tsx src/gunshi.ts"
   },
   "dependencies": {
+    "@gunshi/plugin-completion": "^0.29.0",
     "citty": "^0.1.6",
     "commander": "^12.0.0",
     "gunshi": "^0.29.0",

--- a/typescript-cli-arguments/pnpm-lock.yaml
+++ b/typescript-cli-arguments/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@gunshi/plugin-completion':
+        specifier: ^0.29.0
+        version: 0.29.4(@gunshi/plugin-i18n@0.29.4)(citty@0.1.6)(commander@12.1.0)
       citty:
         specifier: ^0.1.6
         version: 0.1.6
@@ -35,6 +38,21 @@ importers:
         version: 5.9.3
 
 packages:
+
+  '@bomb.sh/tab@0.0.11':
+    resolution: {integrity: sha512-RSqyreeicYBALcMaNxIUJTBknftXsyW45VRq5gKDNwKroh0Re5SDoWwXZaphb+OTEzVdpm/BA8Uq6y0P+AtVYw==}
+    hasBin: true
+    peerDependencies:
+      cac: ^6.7.14
+      citty: ^0.1.6
+      commander: ^13.1.0
+    peerDependenciesMeta:
+      cac:
+        optional: true
+      citty:
+        optional: true
+      commander:
+        optional: true
 
   '@esbuild/aix-ppc64@0.27.7':
     resolution: {integrity: sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==}
@@ -192,6 +210,25 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@gunshi/plugin-completion@0.29.4':
+    resolution: {integrity: sha512-jrhDGFPW93HWNLKz7weJvU5olEYgJU6T/H2d25mehDUB386sv00S2+ZFX8QbhdttU4nR6wgGoYaWwsMaos9n9w==}
+    engines: {node: '>= 20'}
+    peerDependencies:
+      '@gunshi/plugin-i18n': 0.29.4
+
+  '@gunshi/plugin-i18n@0.29.4':
+    resolution: {integrity: sha512-nOBnMzonVhpPyVN2AoFcnYczsUiEg/SAMkU5PB4Hnd8/4yBdm+WxpCdEMGuWrJbh+u07junIpmx2t3noLVktVA==}
+    engines: {node: '>= 20'}
+    peerDependencies:
+      '@gunshi/plugin-global': 0.29.4
+    peerDependenciesMeta:
+      '@gunshi/plugin-global':
+        optional: true
+
+  '@gunshi/plugin@0.29.4':
+    resolution: {integrity: sha512-GuXTSbORBxuGl7M7/l0h3yIblnSZ1HXb+7f8yY3iS9egAWrCOt9wdwPW5I+BvJr7GdQaX209i6Umx8UAqVuMOg==}
+    engines: {node: '>= 20'}
+
   '@types/yargs-parser@21.0.3':
     resolution: {integrity: sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==}
 
@@ -307,6 +344,11 @@ packages:
 
 snapshots:
 
+  '@bomb.sh/tab@0.0.11(citty@0.1.6)(commander@12.1.0)':
+    optionalDependencies:
+      citty: 0.1.6
+      commander: 12.1.0
+
   '@esbuild/aix-ppc64@0.27.7':
     optional: true
 
@@ -384,6 +426,22 @@ snapshots:
 
   '@esbuild/win32-x64@0.27.7':
     optional: true
+
+  '@gunshi/plugin-completion@0.29.4(@gunshi/plugin-i18n@0.29.4)(citty@0.1.6)(commander@12.1.0)':
+    dependencies:
+      '@bomb.sh/tab': 0.0.11(citty@0.1.6)(commander@12.1.0)
+      '@gunshi/plugin': 0.29.4
+      '@gunshi/plugin-i18n': 0.29.4
+    transitivePeerDependencies:
+      - cac
+      - citty
+      - commander
+
+  '@gunshi/plugin-i18n@0.29.4':
+    dependencies:
+      '@gunshi/plugin': 0.29.4
+
+  '@gunshi/plugin@0.29.4': {}
 
   '@types/yargs-parser@21.0.3': {}
 

--- a/typescript-cli-arguments/pnpm-lock.yaml
+++ b/typescript-cli-arguments/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       commander:
         specifier: ^12.0.0
         version: 12.1.0
+      gunshi:
+        specifier: ^0.29.0
+        version: 0.29.4
       meow:
         specifier: ^13.2.0
         version: 13.2.0
@@ -249,6 +252,10 @@ packages:
   get-tsconfig@4.13.7:
     resolution: {integrity: sha512-7tN6rFgBlMgpBML5j8typ92BKFi2sFQvIdpAqLA2beia5avZDrMs0FLZiM5etShWq5irVyGcGMEA1jcDaK7A/Q==}
 
+  gunshi@0.29.4:
+    resolution: {integrity: sha512-Dstvn5GzwR2OpYKJBjYY2YHs31J4d3ht0uKQCex2bLsOD63PmQZX59rYfk5wFhG95jmrVcwbyBzBnolkVDS5kg==}
+    engines: {node: '>= 20'}
+
   is-fullwidth-code-point@3.0.0:
     resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
     engines: {node: '>=8'}
@@ -451,6 +458,8 @@ snapshots:
   get-tsconfig@4.13.7:
     dependencies:
       resolve-pkg-maps: 1.0.0
+
+  gunshi@0.29.4: {}
 
   is-fullwidth-code-point@3.0.0: {}
 

--- a/typescript-cli-arguments/pnpm-lock.yaml
+++ b/typescript-cli-arguments/pnpm-lock.yaml
@@ -1,0 +1,500 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      citty:
+        specifier: ^0.1.6
+        version: 0.1.6
+      commander:
+        specifier: ^12.0.0
+        version: 12.1.0
+      meow:
+        specifier: ^13.2.0
+        version: 13.2.0
+      yargs:
+        specifier: ^17.7.2
+        version: 17.7.2
+    devDependencies:
+      '@types/yargs':
+        specifier: ^17.0.32
+        version: 17.0.35
+      tsx:
+        specifier: ^4.19.0
+        version: 4.21.0
+      typescript:
+        specifier: ^5.4.5
+        version: 5.9.3
+
+packages:
+
+  '@esbuild/aix-ppc64@0.27.7':
+    resolution: {integrity: sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.27.7':
+    resolution: {integrity: sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.27.7':
+    resolution: {integrity: sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.27.7':
+    resolution: {integrity: sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.27.7':
+    resolution: {integrity: sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.27.7':
+    resolution: {integrity: sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.27.7':
+    resolution: {integrity: sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.27.7':
+    resolution: {integrity: sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.27.7':
+    resolution: {integrity: sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.27.7':
+    resolution: {integrity: sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.27.7':
+    resolution: {integrity: sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.27.7':
+    resolution: {integrity: sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.27.7':
+    resolution: {integrity: sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.27.7':
+    resolution: {integrity: sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.27.7':
+    resolution: {integrity: sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.27.7':
+    resolution: {integrity: sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.27.7':
+    resolution: {integrity: sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.27.7':
+    resolution: {integrity: sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.27.7':
+    resolution: {integrity: sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.27.7':
+    resolution: {integrity: sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.27.7':
+    resolution: {integrity: sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.27.7':
+    resolution: {integrity: sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.27.7':
+    resolution: {integrity: sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.27.7':
+    resolution: {integrity: sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.27.7':
+    resolution: {integrity: sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.27.7':
+    resolution: {integrity: sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@types/yargs-parser@21.0.3':
+    resolution: {integrity: sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==}
+
+  '@types/yargs@17.0.35':
+    resolution: {integrity: sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg==}
+
+  ansi-regex@5.0.1:
+    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
+    engines: {node: '>=8'}
+
+  ansi-styles@4.3.0:
+    resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
+    engines: {node: '>=8'}
+
+  citty@0.1.6:
+    resolution: {integrity: sha512-tskPPKEs8D2KPafUypv2gxwJP8h/OaJmC82QQGGDQcHvXX43xF2VDACcJVmZ0EuSxkpO9Kc4MlrA3q0+FG58AQ==}
+
+  cliui@8.0.1:
+    resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
+    engines: {node: '>=12'}
+
+  color-convert@2.0.1:
+    resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
+    engines: {node: '>=7.0.0'}
+
+  color-name@1.1.4:
+    resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+
+  commander@12.1.0:
+    resolution: {integrity: sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==}
+    engines: {node: '>=18'}
+
+  consola@3.4.2:
+    resolution: {integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==}
+    engines: {node: ^14.18.0 || >=16.10.0}
+
+  emoji-regex@8.0.0:
+    resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
+
+  esbuild@0.27.7:
+    resolution: {integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  escalade@3.2.0:
+    resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
+    engines: {node: '>=6'}
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  get-caller-file@2.0.5:
+    resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
+    engines: {node: 6.* || 8.* || >= 10.*}
+
+  get-tsconfig@4.13.7:
+    resolution: {integrity: sha512-7tN6rFgBlMgpBML5j8typ92BKFi2sFQvIdpAqLA2beia5avZDrMs0FLZiM5etShWq5irVyGcGMEA1jcDaK7A/Q==}
+
+  is-fullwidth-code-point@3.0.0:
+    resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
+    engines: {node: '>=8'}
+
+  meow@13.2.0:
+    resolution: {integrity: sha512-pxQJQzB6djGPXh08dacEloMFopsOqGVRKFPYvPOt9XDZ1HasbgDZA74CJGreSU4G3Ak7EFJGoiH2auq+yXISgA==}
+    engines: {node: '>=18'}
+
+  require-directory@2.1.1:
+    resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
+    engines: {node: '>=0.10.0'}
+
+  resolve-pkg-maps@1.0.0:
+    resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
+
+  string-width@4.2.3:
+    resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
+    engines: {node: '>=8'}
+
+  strip-ansi@6.0.1:
+    resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
+    engines: {node: '>=8'}
+
+  tsx@4.21.0:
+    resolution: {integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  wrap-ansi@7.0.0:
+    resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
+    engines: {node: '>=10'}
+
+  y18n@5.0.8:
+    resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
+    engines: {node: '>=10'}
+
+  yargs-parser@21.1.1:
+    resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
+    engines: {node: '>=12'}
+
+  yargs@17.7.2:
+    resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
+    engines: {node: '>=12'}
+
+snapshots:
+
+  '@esbuild/aix-ppc64@0.27.7':
+    optional: true
+
+  '@esbuild/android-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/android-arm@0.27.7':
+    optional: true
+
+  '@esbuild/android-x64@0.27.7':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/darwin-x64@0.27.7':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-arm@0.27.7':
+    optional: true
+
+  '@esbuild/linux-ia32@0.27.7':
+    optional: true
+
+  '@esbuild/linux-loong64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.27.7':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-s390x@0.27.7':
+    optional: true
+
+  '@esbuild/linux-x64@0.27.7':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/sunos-x64@0.27.7':
+    optional: true
+
+  '@esbuild/win32-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/win32-ia32@0.27.7':
+    optional: true
+
+  '@esbuild/win32-x64@0.27.7':
+    optional: true
+
+  '@types/yargs-parser@21.0.3': {}
+
+  '@types/yargs@17.0.35':
+    dependencies:
+      '@types/yargs-parser': 21.0.3
+
+  ansi-regex@5.0.1: {}
+
+  ansi-styles@4.3.0:
+    dependencies:
+      color-convert: 2.0.1
+
+  citty@0.1.6:
+    dependencies:
+      consola: 3.4.2
+
+  cliui@8.0.1:
+    dependencies:
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+      wrap-ansi: 7.0.0
+
+  color-convert@2.0.1:
+    dependencies:
+      color-name: 1.1.4
+
+  color-name@1.1.4: {}
+
+  commander@12.1.0: {}
+
+  consola@3.4.2: {}
+
+  emoji-regex@8.0.0: {}
+
+  esbuild@0.27.7:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.27.7
+      '@esbuild/android-arm': 0.27.7
+      '@esbuild/android-arm64': 0.27.7
+      '@esbuild/android-x64': 0.27.7
+      '@esbuild/darwin-arm64': 0.27.7
+      '@esbuild/darwin-x64': 0.27.7
+      '@esbuild/freebsd-arm64': 0.27.7
+      '@esbuild/freebsd-x64': 0.27.7
+      '@esbuild/linux-arm': 0.27.7
+      '@esbuild/linux-arm64': 0.27.7
+      '@esbuild/linux-ia32': 0.27.7
+      '@esbuild/linux-loong64': 0.27.7
+      '@esbuild/linux-mips64el': 0.27.7
+      '@esbuild/linux-ppc64': 0.27.7
+      '@esbuild/linux-riscv64': 0.27.7
+      '@esbuild/linux-s390x': 0.27.7
+      '@esbuild/linux-x64': 0.27.7
+      '@esbuild/netbsd-arm64': 0.27.7
+      '@esbuild/netbsd-x64': 0.27.7
+      '@esbuild/openbsd-arm64': 0.27.7
+      '@esbuild/openbsd-x64': 0.27.7
+      '@esbuild/openharmony-arm64': 0.27.7
+      '@esbuild/sunos-x64': 0.27.7
+      '@esbuild/win32-arm64': 0.27.7
+      '@esbuild/win32-ia32': 0.27.7
+      '@esbuild/win32-x64': 0.27.7
+
+  escalade@3.2.0: {}
+
+  fsevents@2.3.3:
+    optional: true
+
+  get-caller-file@2.0.5: {}
+
+  get-tsconfig@4.13.7:
+    dependencies:
+      resolve-pkg-maps: 1.0.0
+
+  is-fullwidth-code-point@3.0.0: {}
+
+  meow@13.2.0: {}
+
+  require-directory@2.1.1: {}
+
+  resolve-pkg-maps@1.0.0: {}
+
+  string-width@4.2.3:
+    dependencies:
+      emoji-regex: 8.0.0
+      is-fullwidth-code-point: 3.0.0
+      strip-ansi: 6.0.1
+
+  strip-ansi@6.0.1:
+    dependencies:
+      ansi-regex: 5.0.1
+
+  tsx@4.21.0:
+    dependencies:
+      esbuild: 0.27.7
+      get-tsconfig: 4.13.7
+    optionalDependencies:
+      fsevents: 2.3.3
+
+  typescript@5.9.3: {}
+
+  wrap-ansi@7.0.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+
+  y18n@5.0.8: {}
+
+  yargs-parser@21.1.1: {}
+
+  yargs@17.7.2:
+    dependencies:
+      cliui: 8.0.1
+      escalade: 3.2.0
+      get-caller-file: 2.0.5
+      require-directory: 2.1.1
+      string-width: 4.2.3
+      y18n: 5.0.8
+      yargs-parser: 21.1.1

--- a/typescript-cli-arguments/pnpm-workspace.yaml
+++ b/typescript-cli-arguments/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+allowBuilds:
+  esbuild: false

--- a/typescript-cli-arguments/pnpm-workspace.yaml
+++ b/typescript-cli-arguments/pnpm-workspace.yaml
@@ -1,2 +1,4 @@
 allowBuilds:
   esbuild: false
+
+minimumReleaseAge: 4320

--- a/typescript-cli-arguments/src/citty.ts
+++ b/typescript-cli-arguments/src/citty.ts
@@ -1,0 +1,82 @@
+// CLI argument parsing with citty
+// https://github.com/unjs/citty
+//
+// Run: pnpm citty -- greet Alice --times 3 --shout
+//      pnpm citty -- farewell Bob --formal
+
+import { defineCommand, runMain } from "citty";
+
+// pnpm run inserts '--' before extra arguments; strip it so parsers see clean argv
+if (process.argv[2] === "--") process.argv.splice(2, 1);
+
+const greet = defineCommand({
+  meta: {
+    name: "greet",
+    description: "Greet someone",
+  },
+  args: {
+    name: {
+      type: "positional",
+      description: "the name to greet",
+      required: true,
+    },
+    times: {
+      type: "string",
+      alias: "t",
+      description: "how many times to repeat the greeting",
+      default: "1",
+    },
+    shout: {
+      type: "boolean",
+      alias: "s",
+      description: "shout the greeting in uppercase",
+    },
+  },
+  run({ args }) {
+    const greeting = `Hello, ${args.name}!`;
+    const output = args.shout ? greeting.toUpperCase() : greeting;
+    const times = parseInt(args.times, 10);
+    for (let i = 0; i < times; i++) {
+      console.log(output);
+    }
+  },
+});
+
+const farewell = defineCommand({
+  meta: {
+    name: "farewell",
+    description: "Say farewell to someone",
+  },
+  args: {
+    name: {
+      type: "positional",
+      description: "the name to bid farewell",
+      required: true,
+    },
+    formal: {
+      type: "boolean",
+      alias: "f",
+      description: "use formal language",
+    },
+  },
+  run({ args }) {
+    const message = args.formal
+      ? `Farewell, ${args.name}. It was a pleasure.`
+      : `Bye, ${args.name}!`;
+    console.log(message);
+  },
+});
+
+const main = defineCommand({
+  meta: {
+    name: "greet-demo",
+    version: "1.0.0",
+    description: "A demo CLI for comparing argument parsing libraries",
+  },
+  subCommands: {
+    greet,
+    farewell,
+  },
+});
+
+runMain(main);

--- a/typescript-cli-arguments/src/commander.ts
+++ b/typescript-cli-arguments/src/commander.ts
@@ -1,0 +1,44 @@
+// CLI argument parsing with commander
+// https://github.com/tj/commander.js
+//
+// Run: pnpm commander -- greet Alice --times 3 --shout
+//      pnpm commander -- farewell Bob --formal
+
+import { Command } from "commander";
+
+// pnpm run inserts '--' before extra arguments; strip it so parsers see clean argv
+if (process.argv[2] === "--") process.argv.splice(2, 1);
+
+const program = new Command();
+
+program
+  .name("greet-demo")
+  .description("A demo CLI for comparing argument parsing libraries")
+  .version("1.0.0");
+
+program
+  .command("greet <name>")
+  .description("Greet someone")
+  .option("-t, --times <number>", "how many times to repeat the greeting", "1")
+  .option("-s, --shout", "shout the greeting in uppercase")
+  .action((name: string, options: { times: string; shout?: boolean }) => {
+    const greeting = `Hello, ${name}!`;
+    const output = options.shout ? greeting.toUpperCase() : greeting;
+    const times = parseInt(options.times, 10);
+    for (let i = 0; i < times; i++) {
+      console.log(output);
+    }
+  });
+
+program
+  .command("farewell <name>")
+  .description("Say farewell to someone")
+  .option("-f, --formal", "use formal language")
+  .action((name: string, options: { formal?: boolean }) => {
+    const message = options.formal
+      ? `Farewell, ${name}. It was a pleasure.`
+      : `Bye, ${name}!`;
+    console.log(message);
+  });
+
+program.parse();

--- a/typescript-cli-arguments/src/gunshi.ts
+++ b/typescript-cli-arguments/src/gunshi.ts
@@ -1,0 +1,79 @@
+// CLI argument parsing with gunshi
+// https://github.com/kazupon/gunshi
+//
+// Run: pnpm run gunshi -- greet Alice --times 3 --shout
+//      pnpm run gunshi -- farewell Bob --formal
+
+import { cli, define } from "gunshi";
+
+// pnpm run inserts '--' before extra arguments; strip it so parsers see clean argv
+if (process.argv[2] === "--") process.argv.splice(2, 1);
+
+const greet = define({
+  name: "greet",
+  description: "Greet someone",
+  args: {
+    name: {
+      type: "positional",
+      description: "the name to greet",
+    },
+    times: {
+      type: "number",
+      short: "t",
+      description: "how many times to repeat the greeting",
+      default: 1,
+    },
+    shout: {
+      type: "boolean",
+      short: "s",
+      description: "shout the greeting in uppercase",
+    },
+  },
+  run: (ctx) => {
+    const greeting = `Hello, ${ctx.values.name}!`;
+    const output = ctx.values.shout ? greeting.toUpperCase() : greeting;
+    for (let i = 0; i < (ctx.values.times ?? 1); i++) {
+      console.log(output);
+    }
+  },
+});
+
+const farewell = define({
+  name: "farewell",
+  description: "Say farewell to someone",
+  args: {
+    name: {
+      type: "positional",
+      description: "the name to bid farewell",
+    },
+    formal: {
+      type: "boolean",
+      short: "f",
+      description: "use formal language",
+    },
+  },
+  run: (ctx) => {
+    const message = ctx.values.formal
+      ? `Farewell, ${ctx.values.name}. It was a pleasure.`
+      : `Bye, ${ctx.values.name}!`;
+    console.log(message);
+  },
+});
+
+const main = define({
+  name: "greet-demo",
+  description: "A demo CLI for comparing argument parsing libraries",
+  run: () => {
+    console.log("Please specify a subcommand: greet, farewell");
+  },
+});
+
+await cli(process.argv.slice(2), main, {
+  name: "greet-demo",
+  version: "1.0.0",
+  description: "A demo CLI for comparing argument parsing libraries",
+  subCommands: {
+    greet,
+    farewell,
+  },
+});

--- a/typescript-cli-arguments/src/gunshi.ts
+++ b/typescript-cli-arguments/src/gunshi.ts
@@ -3,8 +3,15 @@
 //
 // Run: pnpm run gunshi -- greet Alice --times 3 --shout
 //      pnpm run gunshi -- farewell Bob --formal
+//
+// Shell completion (via @gunshi/plugin-completion):
+//      pnpm --silent run gunshi -- complete bash    # print bash script
+//      pnpm --silent run gunshi -- complete zsh     # print zsh script
+//      pnpm --silent run gunshi -- complete fish    # print fish script
+//      source <(pnpm --silent run gunshi -- complete bash)  # activate in current shell
 
 import { cli, define } from "gunshi";
+import completion from "@gunshi/plugin-completion";
 
 // pnpm run inserts '--' before extra arguments; strip it so parsers see clean argv
 if (process.argv[2] === "--") process.argv.splice(2, 1);
@@ -72,6 +79,7 @@ await cli(process.argv.slice(2), main, {
   name: "greet-demo",
   version: "1.0.0",
   description: "A demo CLI for comparing argument parsing libraries",
+  plugins: [completion()],
   subCommands: {
     greet,
     farewell,

--- a/typescript-cli-arguments/src/meow.ts
+++ b/typescript-cli-arguments/src/meow.ts
@@ -1,0 +1,69 @@
+// CLI argument parsing with meow
+// https://github.com/sindresorhus/meow
+//
+// Run: pnpm meow -- greet Alice --times 3 --shout
+//      pnpm meow -- farewell Bob --formal
+//
+// Note: meow is designed for single-command CLIs. Subcommands are handled
+// manually by reading the first positional argument and dispatching.
+
+import meow from "meow";
+
+// pnpm run inserts '--' before extra arguments; strip it so parsers see clean argv
+if (process.argv[2] === "--") process.argv.splice(2, 1);
+
+const cli = meow(
+  `
+  Usage
+    $ greet-demo <command> [options]
+
+  Commands
+    greet <name>     Greet someone
+    farewell <name>  Say farewell to someone
+
+  Options (greet)
+    --times, -t  How many times to repeat the greeting  [default: 1]
+    --shout, -s  Shout the greeting in uppercase
+
+  Options (farewell)
+    --formal, -f  Use formal language
+
+  Examples
+    $ greet-demo greet Alice --times 3 --shout
+    $ greet-demo farewell Bob --formal
+`,
+  {
+    importMeta: import.meta,
+    flags: {
+      times: { type: "number", shortFlag: "t", default: 1 },
+      shout: { type: "boolean", shortFlag: "s", default: false },
+      formal: { type: "boolean", shortFlag: "f", default: false },
+    },
+  }
+);
+
+const [command, name] = cli.input;
+
+if (command === "greet") {
+  if (!name) {
+    console.error("Error: <name> is required for the greet command");
+    process.exit(1);
+  }
+  const greeting = `Hello, ${name}!`;
+  const output = cli.flags.shout ? greeting.toUpperCase() : greeting;
+  for (let i = 0; i < cli.flags.times; i++) {
+    console.log(output);
+  }
+} else if (command === "farewell") {
+  if (!name) {
+    console.error("Error: <name> is required for the farewell command");
+    process.exit(1);
+  }
+  const message = cli.flags.formal
+    ? `Farewell, ${name}. It was a pleasure.`
+    : `Bye, ${name}!`;
+  console.log(message);
+} else {
+  cli.showHelp();
+  process.exit(command ? 1 : 0);
+}

--- a/typescript-cli-arguments/src/yargs.ts
+++ b/typescript-cli-arguments/src/yargs.ts
@@ -1,0 +1,71 @@
+// CLI argument parsing with yargs
+// https://yargs.js.org/
+//
+// Run: pnpm yargs -- greet Alice --times 3 --shout
+//      pnpm yargs -- farewell Bob --formal
+
+import yargs from "yargs";
+import { hideBin } from "yargs/helpers";
+
+// pnpm run inserts '--' before extra arguments; strip it so parsers see clean argv
+if (process.argv[2] === "--") process.argv.splice(2, 1);
+
+yargs(hideBin(process.argv))
+  .scriptName("greet-demo")
+  .version("1.0.0")
+  .command(
+    "greet <name>",
+    "Greet someone",
+    (yargs) =>
+      yargs
+        .positional("name", {
+          describe: "the name to greet",
+          type: "string",
+          demandOption: true,
+        })
+        .option("times", {
+          alias: "t",
+          describe: "how many times to repeat the greeting",
+          type: "number",
+          default: 1,
+        })
+        .option("shout", {
+          alias: "s",
+          describe: "shout the greeting in uppercase",
+          type: "boolean",
+          default: false,
+        }),
+    (argv) => {
+      const greeting = `Hello, ${argv.name}!`;
+      const output = argv.shout ? greeting.toUpperCase() : greeting;
+      for (let i = 0; i < argv.times; i++) {
+        console.log(output);
+      }
+    }
+  )
+  .command(
+    "farewell <name>",
+    "Say farewell to someone",
+    (yargs) =>
+      yargs
+        .positional("name", {
+          describe: "the name to bid farewell",
+          type: "string",
+          demandOption: true,
+        })
+        .option("formal", {
+          alias: "f",
+          describe: "use formal language",
+          type: "boolean",
+          default: false,
+        }),
+    (argv) => {
+      const message = argv.formal
+        ? `Farewell, ${argv.name}. It was a pleasure.`
+        : `Bye, ${argv.name}!`;
+      console.log(message);
+    }
+  )
+  .demandCommand(1, "Please specify a command")
+  .strict()
+  .parse();

--- a/typescript-cli-arguments/src/yargs.ts
+++ b/typescript-cli-arguments/src/yargs.ts
@@ -1,8 +1,12 @@
 // CLI argument parsing with yargs
 // https://yargs.js.org/
 //
-// Run: pnpm yargs -- greet Alice --times 3 --shout
-//      pnpm yargs -- farewell Bob --formal
+// Run: pnpm run yargs -- greet Alice --times 3 --shout
+//      pnpm run yargs -- farewell Bob --formal
+//
+// Shell completion (yargs has built-in support):
+//      pnpm --silent run yargs -- completion        # print bash script
+//      source <(pnpm --silent run yargs -- completion)  # activate in current shell
 
 import yargs from "yargs";
 import { hideBin } from "yargs/helpers";
@@ -66,6 +70,7 @@ yargs(hideBin(process.argv))
       console.log(message);
     }
   )
+  .completion("completion", "Generate shell completion script")
   .demandCommand(1, "Please specify a command")
   .strict()
   .parse();

--- a/typescript-cli-arguments/tsconfig.json
+++ b/typescript-cli-arguments/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  }
+}


### PR DESCRIPTION
## Summary
This PR adds a new `typescript-cli-arguments` project that demonstrates and compares four popular Node.js/TypeScript CLI argument parsing libraries: Commander, Yargs, Meow, and Citty.

## Key Changes
- **New project structure**: Added `typescript-cli-arguments/` directory with TypeScript configuration and package setup
- **Four CLI implementations**: Created parallel implementations of the same CLI interface using:
  - **Commander.js**: Traditional command-based approach with fluent API
  - **Yargs**: Chainable builder pattern with automatic help generation
  - **Meow**: Lightweight library designed for single-command CLIs with manual subcommand dispatch
  - **Citty**: UnJS library with declarative command definitions
- **Consistent demo CLI**: All implementations provide identical functionality:
  - `greet <name>` command with `--times/-t` and `--shout/-s` options
  - `farewell <name>` command with `--formal/-f` option
- **Development setup**: Added TypeScript configuration, pnpm workspace configuration, and npm scripts for running each implementation
- **Updated README**: Added entry for the new project in the main README

## Notable Implementation Details
- All implementations handle the pnpm `--` argument separator consistently by stripping it before parsing
- Each library demonstrates its idiomatic patterns and API design philosophy
- The implementations are functionally equivalent, making them suitable for direct comparison
- Uses `tsx` for TypeScript execution without requiring a build step

https://claude.ai/code/session_01QDWChwrxh8QpcPdaMfJGmz