### PR TITLE
Add interactive TUI mode with snooze functionality

### DIFF
--- a/git-dirty-checker/rust/Cargo.toml
+++ b/git-dirty-checker/rust/Cargo.toml
@@ -5,3 +5,7 @@ edition = "2024"
 
 [dependencies]
 rayon = "1.10"
+ratatui = "0.29"
+crossterm = "0.28"
+filetime = "0.2"
+dirs = "5.0"

--- a/git-dirty-checker/rust/src/main.rs
+++ b/git-dirty-checker/rust/src/main.rs
@@ -1,32 +1,57 @@
+use crossterm::{
+    event::{self, Event, KeyCode, KeyEventKind},
+    execute,
+    terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
+};
+use filetime::FileTime;
+use ratatui::{
+    backend::CrosstermBackend,
+    layout::{Constraint, Direction, Layout},
+    style::{Color, Modifier, Style},
+    widgets::{List, ListItem, ListState, Paragraph},
+    Frame, Terminal,
+};
 use rayon::prelude::*;
 use std::env;
 use std::fs;
+use std::io;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
+use std::time::{Duration, SystemTime};
 
 fn main() {
     let args: Vec<String> = env::args().skip(1).collect();
 
-    if args.is_empty() {
-        eprintln!("Usage: git-dirty-checker <directory> [<directory> ...]");
+    let interactive = args.iter().any(|a| a == "--interactive");
+    let dirs: Vec<String> = args.into_iter().filter(|a| !a.starts_with("--")).collect();
+
+    if dirs.is_empty() {
+        eprintln!("Usage: git-dirty-checker [--interactive] <directory> [<directory> ...]");
         eprintln!("\nFinds git repositories with uncommitted changes in subdirectories.");
         std::process::exit(1);
     }
 
-    let repositories: Vec<PathBuf> = args
+    let repositories: Vec<PathBuf> = dirs
         .par_iter()
         .flat_map(|dir| find_subdirectories(dir))
         .collect();
 
-    let dirty_repos: Vec<PathBuf> = repositories
+    let mut dirty_repos: Vec<PathBuf> = repositories
         .par_iter()
         .filter(|repo| is_dirty_repository(repo))
-        .cloned()
+        .filter_map(|repo| fs::canonicalize(repo).ok())
         .collect();
 
-    for repo in dirty_repos {
-        if let Ok(canonical) = fs::canonicalize(&repo) {
-            println!("{}", canonical.display());
+    dirty_repos.sort();
+    dirty_repos.retain(|repo| !is_snoozed(repo));
+
+    if interactive {
+        if let Some(selected) = run_interactive(dirty_repos) {
+            println!("{}", selected.display());
+        }
+    } else {
+        for repo in dirty_repos {
+            println!("{}", repo.display());
         }
     }
 }
@@ -62,4 +87,234 @@ fn is_dirty_repository(path: &Path) -> bool {
         Ok(output) => !output.stdout.is_empty(),
         Err(_) => false,
     }
+}
+
+// --- Snooze ---
+
+fn snooze_dir() -> Option<PathBuf> {
+    let home = dirs::home_dir()?;
+    Some(
+        home.join(".skagedal-tools")
+            .join("git-dirty-checker")
+            .join("snoozed"),
+    )
+}
+
+fn repo_snooze_key(path: &Path) -> String {
+    path.to_string_lossy().replace('/', "__")
+}
+
+fn is_snoozed(path: &Path) -> bool {
+    let Some(dir) = snooze_dir() else {
+        return false;
+    };
+    let snooze_file = dir.join(repo_snooze_key(path));
+    match fs::metadata(&snooze_file) {
+        Ok(metadata) => match metadata.modified() {
+            Ok(mtime) => mtime > SystemTime::now(),
+            Err(_) => false,
+        },
+        Err(_) => false,
+    }
+}
+
+fn snooze_repo(path: &Path) {
+    let Some(dir) = snooze_dir() else {
+        return;
+    };
+    let _ = fs::create_dir_all(&dir);
+    let snooze_file = dir.join(repo_snooze_key(path));
+    let _ = fs::File::create(&snooze_file);
+    let future_time = SystemTime::now()
+        .checked_add(Duration::from_secs(3600))
+        .unwrap();
+    let _ = filetime::set_file_mtime(&snooze_file, FileTime::from_system_time(future_time));
+}
+
+// --- Interactive TUI ---
+
+enum Mode {
+    Normal,
+    Search,
+}
+
+struct App {
+    all_repos: Vec<PathBuf>,
+    filtered_repos: Vec<PathBuf>,
+    selected: usize,
+    mode: Mode,
+    query: String,
+}
+
+impl App {
+    fn new(repos: Vec<PathBuf>) -> Self {
+        let filtered = repos.clone();
+        App {
+            all_repos: repos,
+            filtered_repos: filtered,
+            selected: 0,
+            mode: Mode::Normal,
+            query: String::new(),
+        }
+    }
+
+    fn update_filter(&mut self) {
+        if self.query.is_empty() {
+            self.filtered_repos = self.all_repos.clone();
+        } else {
+            let q = self.query.to_lowercase();
+            self.filtered_repos = self
+                .all_repos
+                .iter()
+                .filter(|p| p.to_string_lossy().to_lowercase().contains(&q))
+                .cloned()
+                .collect();
+        }
+        if self.selected >= self.filtered_repos.len() {
+            self.selected = self.filtered_repos.len().saturating_sub(1);
+        }
+    }
+
+    fn move_up(&mut self) {
+        if self.selected > 0 {
+            self.selected -= 1;
+        }
+    }
+
+    fn move_down(&mut self) {
+        if self.selected + 1 < self.filtered_repos.len() {
+            self.selected += 1;
+        }
+    }
+
+    fn selected_repo(&self) -> Option<&PathBuf> {
+        self.filtered_repos.get(self.selected)
+    }
+
+    fn snooze_selected(&mut self) {
+        if let Some(repo) = self.filtered_repos.get(self.selected).cloned() {
+            snooze_repo(&repo);
+            self.all_repos.retain(|r| r != &repo);
+            self.update_filter();
+        }
+    }
+}
+
+fn run_interactive(repos: Vec<PathBuf>) -> Option<PathBuf> {
+    if repos.is_empty() {
+        return None;
+    }
+
+    enable_raw_mode().ok()?;
+    let mut out = io::stdout();
+    execute!(out, EnterAlternateScreen).ok()?;
+    let backend = CrosstermBackend::new(out);
+    let mut terminal = Terminal::new(backend).ok()?;
+
+    let mut app = App::new(repos);
+    let result = run_app(&mut terminal, &mut app);
+
+    let _ = disable_raw_mode();
+    let _ = execute!(terminal.backend_mut(), LeaveAlternateScreen);
+    let _ = terminal.show_cursor();
+
+    result.ok().flatten()
+}
+
+fn run_app<B: ratatui::backend::Backend>(
+    terminal: &mut Terminal<B>,
+    app: &mut App,
+) -> io::Result<Option<PathBuf>> {
+    loop {
+        terminal.draw(|f| render(f, app))?;
+
+        if let Event::Key(key) = event::read()? {
+            if key.kind != KeyEventKind::Press {
+                continue;
+            }
+
+            match app.mode {
+                Mode::Normal => match key.code {
+                    KeyCode::Esc | KeyCode::Char('q') => return Ok(None),
+                    KeyCode::Enter => return Ok(app.selected_repo().cloned()),
+                    KeyCode::Up | KeyCode::Char('k') => app.move_up(),
+                    KeyCode::Down | KeyCode::Char('j') => app.move_down(),
+                    KeyCode::Char('/') => app.mode = Mode::Search,
+                    KeyCode::Char('s') => {
+                        app.snooze_selected();
+                        if app.filtered_repos.is_empty() {
+                            return Ok(None);
+                        }
+                    }
+                    _ => {}
+                },
+                Mode::Search => match key.code {
+                    KeyCode::Esc => app.mode = Mode::Normal,
+                    KeyCode::Enter => {
+                        app.mode = Mode::Normal;
+                        return Ok(app.selected_repo().cloned());
+                    }
+                    KeyCode::Backspace => {
+                        app.query.pop();
+                        app.update_filter();
+                    }
+                    KeyCode::Up => app.move_up(),
+                    KeyCode::Down => app.move_down(),
+                    KeyCode::Char(c) => {
+                        app.query.push(c);
+                        app.update_filter();
+                    }
+                    _ => {}
+                },
+            }
+        }
+    }
+}
+
+fn render(f: &mut Frame, app: &App) {
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(1),
+            Constraint::Min(0),
+            Constraint::Length(1),
+        ])
+        .split(f.area());
+
+    let header_text = match app.mode {
+        Mode::Normal => "\u{2191}\u{2193}/jk: navigate  /: search  s: snooze 1h  Enter: select  q/Esc: quit",
+        Mode::Search => "\u{2191}\u{2193}: navigate  Enter: select  Esc: back to normal",
+    };
+    f.render_widget(
+        Paragraph::new(header_text).style(Style::default().fg(Color::DarkGray)),
+        chunks[0],
+    );
+
+    let items: Vec<ListItem> = app
+        .filtered_repos
+        .iter()
+        .map(|p| ListItem::new(p.to_string_lossy().to_string()))
+        .collect();
+
+    let list = List::new(items)
+        .highlight_style(
+            Style::default()
+                .fg(Color::Yellow)
+                .add_modifier(Modifier::BOLD),
+        )
+        .highlight_symbol("> ");
+
+    let mut list_state = ListState::default();
+    if !app.filtered_repos.is_empty() {
+        list_state.select(Some(app.selected));
+    }
+    f.render_stateful_widget(list, chunks[1], &mut list_state);
+
+    let footer = match app.mode {
+        Mode::Normal => Paragraph::new(format!("{} dirty repos", app.filtered_repos.len()))
+            .style(Style::default().fg(Color::DarkGray)),
+        Mode::Search => Paragraph::new(format!("/{}", app.query))
+            .style(Style::default().fg(Color::White)),
+    };
+    f.render_widget(footer, chunks[2]);
 }


### PR DESCRIPTION
## Summary
This PR adds an interactive terminal UI mode to git-dirty-checker, allowing users to browse dirty repositories, search through them, and snooze notifications for 1 hour at a time.

## Key Changes
- **Interactive mode**: Added `--interactive` flag that launches a TUI instead of printing results to stdout
- **TUI implementation**: Built with ratatui and crossterm, featuring:
  - List navigation with arrow keys or vim-style (j/k)
  - Search/filter mode triggered with `/`
  - Repository selection with Enter
  - Snooze functionality with `s` key (marks repos as snoozed for 1 hour)
- **Snooze system**: Repositories can be snoozed for 1 hour by creating timestamped files in `~/.skagedal-tools/git-dirty-checker/snoozed/`
- **Filtering**: Snoozed repositories are automatically filtered out from results
- **Sorting**: Dirty repositories are now sorted before display
- **Canonicalization**: Repository paths are canonicalized during collection to ensure consistency

## Implementation Details
- The `App` struct manages state including all repositories, filtered results, selection index, search mode, and query string
- Two modes: Normal (navigation) and Search (text input)
- The snooze mechanism uses file modification times to track expiration
- Interactive mode returns `None` if no repositories are dirty or user cancels
- Non-interactive mode preserves original behavior of printing all dirty repos to stdout

https://claude.ai/code/session_01BuatzgLnCWYcp7uESDefeP