### PR TITLE
Replace manual argument parsing with clap derive macro

### DIFF
--- a/git-dirty-checker/rust/Cargo.toml
+++ b/git-dirty-checker/rust/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
+clap = { version = "*", features = ["derive"] }
 rayon = "1.10"
 ratatui = "0.29"
 crossterm = "0.28"

--- a/git-dirty-checker/rust/src/main.rs
+++ b/git-dirty-checker/rust/src/main.rs
@@ -1,3 +1,4 @@
+use clap::Parser;
 use crossterm::{
     event::{self, Event, KeyCode, KeyEventKind},
     execute,
@@ -12,26 +13,30 @@ use ratatui::{
     Frame, Terminal,
 };
 use rayon::prelude::*;
-use std::env;
 use std::fs;
 use std::io;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::time::{Duration, SystemTime};
 
+/// Finds git repositories with uncommitted changes in subdirectories
+#[derive(Parser, Debug)]
+#[clap(author, version, about, long_about = None)]
+struct Args {
+    /// Run in interactive TUI mode
+    #[clap(long)]
+    interactive: bool,
+
+    /// Directories to search for git repositories
+    #[clap(required = true)]
+    dirs: Vec<String>,
+}
+
 fn main() {
-    let args: Vec<String> = env::args().skip(1).collect();
+    let args = Args::parse();
 
-    let interactive = args.iter().any(|a| a == "--interactive");
-    let dirs: Vec<String> = args.into_iter().filter(|a| !a.starts_with("--")).collect();
-
-    if dirs.is_empty() {
-        eprintln!("Usage: git-dirty-checker [--interactive] <directory> [<directory> ...]");
-        eprintln!("\nFinds git repositories with uncommitted changes in subdirectories.");
-        std::process::exit(1);
-    }
-
-    let repositories: Vec<PathBuf> = dirs
+    let repositories: Vec<PathBuf> = args
+        .dirs
         .par_iter()
         .flat_map(|dir| find_subdirectories(dir))
         .collect();
@@ -45,7 +50,7 @@ fn main() {
     dirty_repos.sort();
     dirty_repos.retain(|repo| !is_snoozed(repo));
 
-    if interactive {
+    if args.interactive {
         if let Some(selected) = run_interactive(dirty_repos) {
             println!("{}", selected.display());
         }


### PR DESCRIPTION
## Summary
Refactored command-line argument parsing to use the `clap` crate with derive macros instead of manual `std::env` parsing. This improves code maintainability and provides automatic help/version output.

## Key Changes
- Replaced manual `env::args()` parsing with `clap::Parser` derive macro
- Created `Args` struct with documented fields for `--interactive` flag and directory arguments
- Removed manual validation logic (now handled by clap's `required = true`)
- Simplified `main()` function by delegating argument parsing to `Args::parse()`
- Added `clap` dependency with `derive` feature to `Cargo.toml`

## Implementation Details
- The `Args` struct uses `#[clap(long)]` for the `--interactive` flag and `#[clap(required = true)]` for the `dirs` vector
- Doc comments on struct and fields are automatically used by clap for help text generation
- The `#[clap(author, version, about, long_about = None)]` attributes provide standard CLI metadata
- Removed the manual usage error message as clap provides this automatically

https://claude.ai/code/session_01DeqrjAeX5F1zQuor5h1jQC