### PR TITLE
Improve interactive mode: inline viewport, snooze management, and UI enhancements

### DIFF
--- a/git-dirty-checker/README.md
+++ b/git-dirty-checker/README.md
@@ -29,11 +29,17 @@ cargo run --release -- /path/to/repos /another/path
 ## Features
 
 - **Parallel processing**: Uses Rayon to check multiple repositories concurrently
-- **Interactive TUI mode**: Run with `--interactive` for a terminal UI with navigation and snooze support
+- **Interactive mode**: Run with `--interactive` for an inline UI with navigation and snooze support
   - Navigate with `j`/`k` or arrow keys
   - Search with `/`
-  - Snooze a repository for 1 hour with `s`
+  - Snooze a repository for 1 hour with `s`; press `s` again on a snoozed repo to add another hour
+  - Unsnooze a repository with `u`
+  - Snoozed repos remain visible in grey at the bottom of the list
 - **Output**: Prints full paths of repositories with uncommitted changes, one per line (non-interactive mode)
+
+## Integration with `assistant` / `SUGGESTED_CD_FILE`
+
+When the interactive mode selection results in a directory, the tool checks the `SUGGESTED_CD_FILE` environment variable. If set, it writes the selected path to that file and exits with code `10` instead of printing to stdout. This follows the convention used by the `assistant` program, which uses this mechanism to `cd` the calling shell into the selected directory.
 
 ## Requirements
 

--- a/git-dirty-checker/README.md
+++ b/git-dirty-checker/README.md
@@ -29,7 +29,7 @@ cargo run --release -- /path/to/repos /another/path
 ## Features
 
 - **Parallel processing**: Uses Rayon to check multiple repositories concurrently
-- **Interactive mode**: Run with `--interactive` for an inline UI with navigation and snooze support
+- **Interactive mode**: Run with `--interactive` for an inline UI with navigation and snooze support. Pass `--exit-if-no-active-dirty` together with `--interactive` to exit silently when all dirty repos are snoozed.
   - Navigate with `j`/`k` or arrow keys
   - Search with `/`
   - Snooze a repository for 1 hour with `s`; press `s` again on a snoozed repo to add another hour

--- a/git-dirty-checker/src/main.rs
+++ b/git-dirty-checker/src/main.rs
@@ -1,8 +1,7 @@
 use clap::Parser;
 use crossterm::{
     event::{self, Event, KeyCode, KeyEventKind},
-    execute,
-    terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
+    terminal::{disable_raw_mode, enable_raw_mode},
 };
 use filetime::FileTime;
 use ratatui::{
@@ -10,9 +9,10 @@ use ratatui::{
     layout::{Constraint, Direction, Layout},
     style::{Color, Modifier, Style},
     widgets::{List, ListItem, ListState, Paragraph},
-    Frame, Terminal,
+    Frame, Terminal, TerminalOptions, Viewport,
 };
 use rayon::prelude::*;
+use std::collections::HashMap;
 use std::fs;
 use std::io;
 use std::path::{Path, PathBuf};
@@ -23,7 +23,7 @@ use std::time::{Duration, SystemTime};
 #[derive(Parser, Debug)]
 #[clap(author, version, about, long_about = None)]
 struct Args {
-    /// Run in interactive TUI mode
+    /// Run in interactive mode
     #[clap(long)]
     interactive: bool,
 
@@ -48,15 +48,16 @@ fn main() {
         .collect();
 
     dirty_repos.sort();
-    dirty_repos.retain(|repo| !is_snoozed(repo));
 
     if args.interactive {
         if let Some(selected) = run_interactive(dirty_repos) {
             println!("{}", selected.display());
         }
     } else {
-        for repo in dirty_repos {
-            println!("{}", repo.display());
+        for repo in &dirty_repos {
+            if !is_snoozed(repo) {
+                println!("{}", repo.display());
+            }
         }
     }
 }
@@ -110,16 +111,18 @@ fn repo_snooze_key(path: &Path) -> String {
 }
 
 fn is_snoozed(path: &Path) -> bool {
-    let Some(dir) = snooze_dir() else {
-        return false;
-    };
+    get_snooze_expiry(path).is_some()
+}
+
+fn get_snooze_expiry(path: &Path) -> Option<SystemTime> {
+    let dir = snooze_dir()?;
     let snooze_file = dir.join(repo_snooze_key(path));
-    match fs::metadata(&snooze_file) {
-        Ok(metadata) => match metadata.modified() {
-            Ok(mtime) => mtime > SystemTime::now(),
-            Err(_) => false,
-        },
-        Err(_) => false,
+    let metadata = fs::metadata(&snooze_file).ok()?;
+    let mtime = metadata.modified().ok()?;
+    if mtime > SystemTime::now() {
+        Some(mtime)
+    } else {
+        None
     }
 }
 
@@ -130,13 +133,21 @@ fn snooze_repo(path: &Path) {
     let _ = fs::create_dir_all(&dir);
     let snooze_file = dir.join(repo_snooze_key(path));
     let _ = fs::File::create(&snooze_file);
-    let future_time = SystemTime::now()
-        .checked_add(Duration::from_secs(3600))
-        .unwrap();
+    // Extend from current expiry if already snoozed, otherwise from now
+    let base_time = get_snooze_expiry(path).unwrap_or_else(SystemTime::now);
+    let future_time = base_time.checked_add(Duration::from_secs(3600)).unwrap();
     let _ = filetime::set_file_mtime(&snooze_file, FileTime::from_system_time(future_time));
 }
 
-// --- Interactive TUI ---
+fn unsnooze_repo(path: &Path) {
+    let Some(dir) = snooze_dir() else {
+        return;
+    };
+    let snooze_file = dir.join(repo_snooze_key(path));
+    let _ = fs::remove_file(snooze_file);
+}
+
+// --- Interactive mode ---
 
 enum Mode {
     Normal,
@@ -146,6 +157,7 @@ enum Mode {
 struct App {
     all_repos: Vec<PathBuf>,
     filtered_repos: Vec<PathBuf>,
+    snoozed: HashMap<PathBuf, SystemTime>,
     selected: usize,
     mode: Mode,
     query: String,
@@ -153,10 +165,27 @@ struct App {
 
 impl App {
     fn new(repos: Vec<PathBuf>) -> Self {
-        let filtered = repos.clone();
+        // repos is already sorted alphabetically
+        let mut snoozed: HashMap<PathBuf, SystemTime> = HashMap::new();
+        for repo in &repos {
+            if let Some(expiry) = get_snooze_expiry(repo) {
+                snoozed.insert(repo.clone(), expiry);
+            }
+        }
+
+        // Unsnoozed repos first, snoozed repos at bottom (preserving alphabetical order within each group)
+        let mut ordered: Vec<PathBuf> = repos
+            .iter()
+            .filter(|r| !snoozed.contains_key(*r))
+            .cloned()
+            .collect();
+        ordered.extend(repos.iter().filter(|r| snoozed.contains_key(*r)).cloned());
+
+        let filtered = ordered.clone();
         App {
-            all_repos: repos,
+            all_repos: ordered,
             filtered_repos: filtered,
+            snoozed,
             selected: 0,
             mode: Mode::Normal,
             query: String::new(),
@@ -199,9 +228,34 @@ impl App {
     fn snooze_selected(&mut self) {
         if let Some(repo) = self.filtered_repos.get(self.selected).cloned() {
             snooze_repo(&repo);
-            self.all_repos.retain(|r| r != &repo);
-            self.update_filter();
+            if let Some(expiry) = get_snooze_expiry(&repo) {
+                self.snoozed.insert(repo, expiry);
+            }
         }
+    }
+
+    fn unsnooze_selected(&mut self) {
+        if let Some(repo) = self.filtered_repos.get(self.selected).cloned() {
+            unsnooze_repo(&repo);
+            self.snoozed.remove(&repo);
+        }
+    }
+}
+
+fn format_snooze_remaining(expiry: &SystemTime) -> String {
+    let now = SystemTime::now();
+    match expiry.duration_since(now) {
+        Ok(remaining) => {
+            let total_secs = remaining.as_secs();
+            let hours = total_secs / 3600;
+            let minutes = (total_secs % 3600) / 60;
+            if hours > 0 {
+                format!("{}h{}m", hours, minutes)
+            } else {
+                format!("{}m", minutes)
+            }
+        }
+        Err(_) => "expired".to_string(),
     }
 }
 
@@ -210,18 +264,25 @@ fn run_interactive(repos: Vec<PathBuf>) -> Option<PathBuf> {
         return None;
     }
 
+    let (_, terminal_rows) = crossterm::terminal::size().unwrap_or((80, 24));
+    let max_height = (terminal_rows as usize).saturating_sub(2).max(3);
+    let height = (repos.len() + 2).min(max_height) as u16;
+
     enable_raw_mode().ok()?;
-    let mut out = io::stdout();
-    execute!(out, EnterAlternateScreen).ok()?;
-    let backend = CrosstermBackend::new(out);
-    let mut terminal = Terminal::new(backend).ok()?;
+    let stdout = io::stdout();
+    let backend = CrosstermBackend::new(stdout);
+    let mut terminal = Terminal::with_options(
+        backend,
+        TerminalOptions {
+            viewport: Viewport::Inline(height),
+        },
+    )
+    .ok()?;
 
     let mut app = App::new(repos);
     let result = run_app(&mut terminal, &mut app);
 
     let _ = disable_raw_mode();
-    let _ = execute!(terminal.backend_mut(), LeaveAlternateScreen);
-    let _ = terminal.show_cursor();
 
     result.ok().flatten()
 }
@@ -245,12 +306,8 @@ fn run_app<B: ratatui::backend::Backend>(
                     KeyCode::Up | KeyCode::Char('k') => app.move_up(),
                     KeyCode::Down | KeyCode::Char('j') => app.move_down(),
                     KeyCode::Char('/') => app.mode = Mode::Search,
-                    KeyCode::Char('s') => {
-                        app.snooze_selected();
-                        if app.filtered_repos.is_empty() {
-                            return Ok(None);
-                        }
-                    }
+                    KeyCode::Char('s') => app.snooze_selected(),
+                    KeyCode::Char('u') => app.unsnooze_selected(),
                     _ => {}
                 },
                 Mode::Search => match key.code {
@@ -287,8 +344,8 @@ fn render(f: &mut Frame, app: &App) {
         .split(f.area());
 
     let header_text = match app.mode {
-        Mode::Normal => "\u{2191}\u{2193}/jk: navigate  /: search  s: snooze 1h  Enter: select  q/Esc: quit",
-        Mode::Search => "\u{2191}\u{2193}: navigate  Enter: select  Esc: back to normal",
+        Mode::Normal => "↑↓/jk: navigate  /: search  s: snooze +1h  u: unsnooze  Enter: select  q/Esc: quit",
+        Mode::Search => "↑↓: navigate  Enter: select  Esc: back to normal",
     };
     f.render_widget(
         Paragraph::new(header_text).style(Style::default().fg(Color::DarkGray)),
@@ -298,7 +355,19 @@ fn render(f: &mut Frame, app: &App) {
     let items: Vec<ListItem> = app
         .filtered_repos
         .iter()
-        .map(|p| ListItem::new(p.to_string_lossy().to_string()))
+        .map(|p| {
+            if let Some(expiry) = app.snoozed.get(p) {
+                let remaining = format_snooze_remaining(expiry);
+                ListItem::new(format!(
+                    "{} (snoozed {})",
+                    p.to_string_lossy(),
+                    remaining
+                ))
+                .style(Style::default().fg(Color::DarkGray))
+            } else {
+                ListItem::new(p.to_string_lossy().to_string())
+            }
+        })
         .collect();
 
     let list = List::new(items)
@@ -316,8 +385,23 @@ fn render(f: &mut Frame, app: &App) {
     f.render_stateful_widget(list, chunks[1], &mut list_state);
 
     let footer = match app.mode {
-        Mode::Normal => Paragraph::new(format!("{} dirty repos", app.filtered_repos.len()))
-            .style(Style::default().fg(Color::DarkGray)),
+        Mode::Normal => {
+            let snoozed_count = app
+                .filtered_repos
+                .iter()
+                .filter(|r| app.snoozed.contains_key(*r))
+                .count();
+            let text = if snoozed_count > 0 {
+                format!(
+                    "{} dirty repos ({} snoozed)",
+                    app.filtered_repos.len(),
+                    snoozed_count
+                )
+            } else {
+                format!("{} dirty repos", app.filtered_repos.len())
+            };
+            Paragraph::new(text).style(Style::default().fg(Color::DarkGray))
+        }
         Mode::Search => Paragraph::new(format!("/{}", app.query))
             .style(Style::default().fg(Color::White)),
     };

--- a/git-dirty-checker/src/main.rs
+++ b/git-dirty-checker/src/main.rs
@@ -27,6 +27,10 @@ struct Args {
     #[clap(long)]
     interactive: bool,
 
+    /// In interactive mode, exit silently if there are no unsnoozed dirty repos
+    #[clap(long)]
+    exit_if_no_active_dirty: bool,
+
     /// Directories to search for git repositories
     #[clap(required = true)]
     dirs: Vec<String>,
@@ -50,6 +54,9 @@ fn main() {
     dirty_repos.sort();
 
     if args.interactive {
+        if args.exit_if_no_active_dirty && dirty_repos.iter().all(|r| is_snoozed(r)) {
+            return;
+        }
         if let Some(selected) = run_interactive(dirty_repos) {
             output_selected(&selected);
         }

--- a/git-dirty-checker/src/main.rs
+++ b/git-dirty-checker/src/main.rs
@@ -16,7 +16,7 @@ use std::collections::HashMap;
 use std::fs;
 use std::io;
 use std::path::{Path, PathBuf};
-use std::process::{Command, Stdio};
+use std::process::{self, Command, Stdio};
 use std::time::{Duration, SystemTime};
 
 /// Finds git repositories with uncommitted changes in subdirectories
@@ -51,7 +51,7 @@ fn main() {
 
     if args.interactive {
         if let Some(selected) = run_interactive(dirty_repos) {
-            println!("{}", selected.display());
+            output_selected(&selected);
         }
     } else {
         for repo in &dirty_repos {
@@ -59,6 +59,15 @@ fn main() {
                 println!("{}", repo.display());
             }
         }
+    }
+}
+
+fn output_selected(path: &Path) {
+    if let Ok(file) = std::env::var("SUGGESTED_CD_FILE") {
+        let _ = fs::write(&file, path.to_string_lossy().as_bytes());
+        process::exit(10);
+    } else {
+        println!("{}", path.display());
     }
 }
 


### PR DESCRIPTION
## Summary
This PR enhances the interactive TUI mode with better snooze management, improved terminal handling, and a more polished user interface. The changes move from full-screen alternate screen mode to an inline viewport that integrates better with the terminal, add the ability to unsnooze repositories, and provide visual feedback for snoozed items.

## Key Changes

- **Terminal handling**: Switched from alternate screen mode (`EnterAlternateScreen`/`LeaveAlternateScreen`) to inline viewport mode using `TerminalOptions` with `Viewport::Inline`. This allows the interactive UI to display inline without taking over the entire terminal.

- **Snooze state management**: 
  - Added `HashMap<PathBuf, SystemTime>` to track snoozed repositories and their expiry times
  - Introduced `get_snooze_expiry()` function to retrieve snooze expiry time
  - Added `unsnooze_repo()` function to remove snooze status
  - Modified `snooze_repo()` to extend from current expiry if already snoozed, rather than always from now

- **Interactive mode improvements**:
  - Snoozed repositories now appear at the bottom of the list while maintaining alphabetical order within each group
  - Added 'u' keybinding to unsnooze selected repository
  - Snoozed items display with gray styling and remaining snooze time (e.g., "2h30m")
  - Footer now shows count of snoozed repositories when applicable

- **UI/UX enhancements**:
  - Updated help text to use Unicode arrows (↑↓) instead of escape sequences
  - Changed snooze help text from "snooze 1h" to "snooze +1h" to clarify it extends time
  - Improved footer to display snoozed count alongside total dirty repos count
  - Added `format_snooze_remaining()` function to display human-readable remaining snooze time

- **Non-interactive mode**: Moved snooze filtering to the output loop instead of pre-filtering, allowing the interactive mode to display all repositories with snooze status visible.

- **Code cleanup**: Removed unused imports (`execute`, `EnterAlternateScreen`, `LeaveAlternateScreen`) and simplified error handling in snooze-related functions.

https://claude.ai/code/session_01EM1cEmjBeVXwzVqAYCjsFp