### PR TITLE
Add cloudwatch-insights tool

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,6 +49,15 @@ All Node.js/TypeScript projects in this repository must follow these guidelines:
   ```
   This is a pnpm supply-chain security feature that prevents installing package versions
   published fewer than 3 days ago, giving the community time to detect and pull compromised releases.
+- Use **[gunshi](https://github.com/kazupon/gunshi)** for CLI argument parsing. It is
+  declarative (`define({ args, run })` + `cli()`), written in TypeScript with inferred
+  argument types, and supports shell completion via `@gunshi/plugin-completion`. Prefer
+  it over commander/yargs/meow/citty for new tools. See `typescript-cli-arguments/src/gunshi.ts`
+  for a reference setup, including subcommands and completion.
+  - gunshi is ESM-first and requires Node.js ≥ 20. Set `"type": "module"` in `package.json`
+    and use `"module": "NodeNext"` + `"moduleResolution": "NodeNext"` in `tsconfig.json`.
+  - Pass `renderHeader: null` to `cli()` when you don't want the command description
+    reprinted before every invocation.
 
 ## Rust Projects
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,6 +59,27 @@ All Node.js/TypeScript projects in this repository must follow these guidelines:
   - Pass `renderHeader: null` to `cli()` when you don't want the command description
     reprinted before every invocation.
 
+## Per-tool Config and State Directories
+
+When a tool needs to store user-scoped config or state on disk (config
+files, caches, snooze records, etc.), put it under:
+
+```
+~/.skagedal-tools/<tool-name>/
+```
+
+For example, `git-dirty-checker` stores its snooze records in
+`~/.skagedal-tools/git-dirty-checker/snoozed/`, and `cloudwatch-insights`
+reads `~/.skagedal-tools/cloudwatch-insights/settings.toml`.
+
+Do not use `~/.config/<tool>/` or `$XDG_CONFIG_HOME` — those aren't
+meaningfully portable to macOS (the OS convention there is
+`~/Library/Application Support/`), and keeping everything under
+`~/.skagedal-tools/` makes it easy to back up, wipe, or sync as a group.
+
+Tools may honor a `SKAGEDAL_TOOLS_HOME` environment variable to
+override the base directory (primarily useful for tests).
+
 ## Rust Projects
 
 All Rust projects in this repository must follow these guidelines:

--- a/README.md
+++ b/README.md
@@ -12,3 +12,4 @@ A collection of small tools.
 | [typescript-cli-arguments](typescript-cli-arguments/) | Side-by-side comparison of CLI argument parsing libraries for Node.js/TypeScript |
 | [x-java-home](x-java-home/) | A drop-in replacement for macOS java_home with JSON output support |
 | [linear-notifications](linear-notifications/) | Interactive CLI for viewing and opening unread Linear notifications |
+| [cloudwatch-insights](cloudwatch-insights/) | Download logs from AWS CloudWatch Logs Insights with a flexible time-range syntax |

--- a/cloudwatch-insights/.gitignore
+++ b/cloudwatch-insights/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+dist/

--- a/cloudwatch-insights/README.md
+++ b/cloudwatch-insights/README.md
@@ -72,9 +72,9 @@ Overridable with `$XDG_CONFIG_HOME` or the explicit `$CLOUDWATCH_INSIGHTS_CONFIG
 
 ```toml
 # settings.toml
-[installer-notification]
-group = "/{env}/team-icc"
-app   = "installer-notification"
+[my-service]
+group = "/{env}/my-team"
+app   = "my-service"
 
 [another-repo]
 group = "/prod/another"
@@ -98,9 +98,8 @@ Substituted into `{env}` in the log group template (either from config or from `
 
 ### Output formats
 
-- `ndjson` (default) — one JSON object per row, one row per line.
+- `jsonl` (default) — one JSON object per row, one row per line.
 - `json` — a pretty-printed JSON array.
-- `tsv` — tab-separated values with a header row (`@ptr` is omitted).
 
 Progress (query status, row counts, byte totals) is written to stderr so piping stdout is safe. Use `--quiet` to silence it.
 

--- a/cloudwatch-insights/README.md
+++ b/cloudwatch-insights/README.md
@@ -4,7 +4,7 @@ Download logs from [AWS CloudWatch Logs Insights](https://docs.aws.amazon.com/Am
 
 ## Requirements
 
-- [Node.js](https://nodejs.org) (v18+)
+- [Node.js](https://nodejs.org) (v20+, required by [gunshi](https://github.com/kazupon/gunshi))
 - AWS credentials available through the standard SDK chain (env vars, `~/.aws/credentials`, SSO, IMDS, …)
 
 ## Installation

--- a/cloudwatch-insights/README.md
+++ b/cloudwatch-insights/README.md
@@ -1,6 +1,6 @@
 # cloudwatch-insights
 
-Download logs from [AWS CloudWatch Logs Insights](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/AnalyzingLogData.html) from the command line, with a flexible time-range syntax and per-git-repository defaults.
+Download logs from [AWS CloudWatch Logs Insights](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/AnalyzingLogData.html) from the command line, with a flexible time-range syntax, per-git-repository defaults, and persistent editable query files.
 
 ## Requirements
 
@@ -15,39 +15,97 @@ Install globally using pnpm:
 pnpm link --global
 ```
 
-This builds the TypeScript source and installs the `cloudwatch-insights` command on your `PATH`. After installation you can run `cloudwatch-insights` from anywhere.
+This builds the TypeScript source and installs the `cloudwatch-insights` command on your `PATH`. The `install.sh` at the repo root does the same for every tool in the repo.
 
-> `pnpm install -g .` is broken in pnpm v10, so use `pnpm link --global`.
+## Subcommands
 
-## Usage
-
-```sh
-cloudwatch-insights -g <log-group> [-t <time-range>] [-q '<insights query>']
+```
+cloudwatch-insights query [options]       run a query
+cloudwatch-insights show                  stream the latest run to stdout
+cloudwatch-insights edit-config           edit the per-repo config
 ```
 
-### Examples
+### `query`
+
+By default, `query` opens your `$EDITOR` (or `$VISUAL`) on a persistent `current.insights` file so you can tweak the query and its parameters. Save and exit, and the query runs. Pass `--query` or `--query-file` to skip the editor.
 
 ```sh
-# Last 5 hours of a default query (fields @timestamp, @message | sort @timestamp desc)
-cloudwatch-insights -g /aws/lambda/my-func -t 5h
+# First run: seeds current.insights from your config, opens it in $EDITOR
+cloudwatch-insights query
 
-# A specific minute today, with a custom query
-cloudwatch-insights -g /aws/lambda/my-func -t 13.00-13.01 \
+# Subsequent runs: reuse the same file (edit, save, exit, execute)
+cloudwatch-insights query
+
+# Skip the editor with an inline query
+cloudwatch-insights query -g /aws/lambda/my-func -t 5h \
   -q 'fields @timestamp, @message | filter @message like /ERROR/'
 
-# Millisecond granularity
-cloudwatch-insights -g /my/group -t 09:15:00.000-09:15:00.500
-
-# A time range on a named day
-cloudwatch-insights -g /my/group -t "yesterday 17-18"
-
-# No -g needed when there's a matching config section — just supply --environment
-cloudwatch-insights -t 30m -e systest
+# Override the time range at invocation time
+cloudwatch-insights query -t "yesterday 17-18" -e systest
 ```
 
-### Time-range syntax
+Results are written as JSONL to:
 
-The `-t / --time` flag defaults to `1h` (last hour). It accepts, in order of precedence:
+```
+~/.skagedal-tools/cloudwatch-insights/queries/<repo>/results/run-<timestamp>.jsonl
+```
+
+The path of the run file is the only thing printed to stdout, making it easy to capture:
+
+```sh
+last=$(cloudwatch-insights query)
+jq . < "$last"
+```
+
+After every successful run the symlink `~/.skagedal-tools/cloudwatch-insights/latest-run.jsonl` is updated to point at the new file.
+
+### `show`
+
+```sh
+cloudwatch-insights show
+cloudwatch-insights show | jq .
+```
+
+Streams `~/.skagedal-tools/cloudwatch-insights/latest-run.jsonl` to stdout. Handy for re-inspecting or re-formatting the most recent run without re-querying.
+
+### `edit-config`
+
+```sh
+cloudwatch-insights edit-config
+```
+
+Opens `~/.skagedal-tools/cloudwatch-insights/settings.toml` in `$EDITOR`, creating the file (and a commented placeholder section for the current git repository) on first use.
+
+## The `.insights` file format
+
+`current.insights` has an optional YAML **front-matter** block (fenced by `---` lines) followed by the query body:
+
+```
+---
+time: 5h
+environment: systest
+logGroup: /my/group
+limit: 200
+---
+fields @timestamp, @message, app
+| filter app = "my-service"
+| sort @timestamp desc
+```
+
+Front-matter fields:
+
+| Field         | Purpose                                                             |
+|---------------|---------------------------------------------------------------------|
+| `time`        | time range (same syntax as `--time`)                                |
+| `environment` | substituted for `{env}` in log group templates                       |
+| `logGroup`    | a log group, or an array of log groups                               |
+| `limit`       | row limit                                                           |
+
+CLI flags always win over front-matter, and front-matter wins over the repo defaults in `settings.toml`.
+
+## Time-range syntax
+
+The `-t / --time` flag (and the front-matter `time:` key) accepts, in order of precedence:
 
 | Form | Examples | Meaning |
 |------|----------|---------|
@@ -60,7 +118,9 @@ The `-t / --time` flag defaults to `1h` (last hour). It accepts, in order of pre
 
 Times use `.` or `:` as the sub-separator. Milliseconds are introduced with a `.` after the seconds (e.g. `09:15:00.500`).
 
-### Per-repository defaults (`settings.toml`)
+Default: **1h** (last hour) if neither CLI nor front-matter specifies one.
+
+## Per-repository defaults (`settings.toml`)
 
 The tool detects the git repository you're running it from (via `git rev-parse --show-toplevel`) and looks up a section keyed by the repo's directory name in:
 
@@ -68,15 +128,9 @@ The tool detects the git repository you're running it from (via `git rev-parse -
 ~/.skagedal-tools/cloudwatch-insights/settings.toml
 ```
 
-Per the skagedal-tools convention, per-tool state lives under `~/.skagedal-tools/<tool-name>/`. Override the whole base directory with `$SKAGEDAL_TOOLS_HOME`, or point at an arbitrary file with `$CLOUDWATCH_INSIGHTS_CONFIG`.
+Per the skagedal-tools convention, per-tool state lives under `~/.skagedal-tools/<tool-name>/`. Override the whole base directory with `$SKAGEDAL_TOOLS_HOME`, or point at an arbitrary config file with `$CLOUDWATCH_INSIGHTS_CONFIG`.
 
-To open (and, if necessary, create) the settings file:
-
-```sh
-cloudwatch-insights edit-config
-```
-
-This opens the file in `$VISUAL` (falling back to `$EDITOR`). On first use the file is seeded with a commented template. When run from inside a git repository, a commented placeholder section for that repo is appended too — just uncomment the lines and fill in the values.
+Example:
 
 ```toml
 # settings.toml
@@ -90,28 +144,34 @@ group = "/prod/another"
 
 Fields:
 
-- `group` — log group used when `--log-group` is not given. The literal string `{env}` is substituted with the value of `--environment`.
-- `app` — if neither `--query` nor `--query-file` is given, the default query becomes:
-  ```
-  fields @timestamp, @message, app | filter app = "<app>" | sort @timestamp desc
-  ```
+- `group` — log group used when no `--log-group` / front-matter `logGroup` is given. `{env}` is substituted with `--environment`.
+- `app` — used only when seeding a fresh `current.insights`: the seeded query body will filter on `app = "<app>"`.
 
-### `--environment`
+## `--environment`
 
 ```
 -e, --environment <env>      systest | uat | prod
 ```
 
-Substituted into `{env}` in the log group template (either from config or from `--log-group`). Required whenever the template contains `{env}`.
+Substituted into `{env}` in the log group template (from CLI, front-matter, or config). Required whenever the template contains `{env}`.
 
-### Output formats
+## Directory layout
 
-- `jsonl` (default) — one JSON object per row, one row per line.
-- `json` — a pretty-printed JSON array.
+```
+~/.skagedal-tools/cloudwatch-insights/
+├── settings.toml                       # per-repo defaults
+├── latest-run.jsonl                    # symlink to the most recent run
+└── queries/
+    ├── <repo-name>/
+    │   ├── current.insights            # editor file for `query`
+    │   └── results/
+    │       └── run-<timestamp>.jsonl
+    └── _default/                       # used when run outside any git repo
+        ├── current.insights
+        └── results/
+```
 
-Progress (query status, row counts, byte totals) is written to stderr so piping stdout is safe. Use `--quiet` to silence it.
-
-### Credentials and region
+## Credentials and region
 
 Standard AWS SDK resolution applies:
 
@@ -123,7 +183,7 @@ Standard AWS SDK resolution applies:
 
 ```sh
 pnpm install
-pnpm build                         # compile TypeScript to dist/
-pnpm dev -- -g /my/group -t 5h     # run directly from src/ via tsx
-pnpm test                          # time-range + config tests
+pnpm build                                   # compile TypeScript to dist/
+pnpm dev -- query -g /my/group -t 5h         # run directly from src/ via tsx
+pnpm test                                    # time-range, config, query-file tests
 ```

--- a/cloudwatch-insights/README.md
+++ b/cloudwatch-insights/README.md
@@ -65,10 +65,10 @@ Times use `.` or `:` as the sub-separator. Milliseconds are introduced with a `.
 The tool detects the git repository you're running it from (via `git rev-parse --show-toplevel`) and looks up a section keyed by the repo's directory name in:
 
 ```
-~/.config/cloudwatch-insights/settings.toml
+~/.skagedal-tools/cloudwatch-insights/settings.toml
 ```
 
-Overridable with `$XDG_CONFIG_HOME` or the explicit `$CLOUDWATCH_INSIGHTS_CONFIG` env var.
+Per the skagedal-tools convention, per-tool state lives under `~/.skagedal-tools/<tool-name>/`. Override the whole base directory with `$SKAGEDAL_TOOLS_HOME`, or point at an arbitrary file with `$CLOUDWATCH_INSIGHTS_CONFIG`.
 
 ```toml
 # settings.toml

--- a/cloudwatch-insights/README.md
+++ b/cloudwatch-insights/README.md
@@ -85,11 +85,12 @@ Opens `~/.skagedal-tools/cloudwatch-insights/settings.toml` in `$EDITOR`, creati
 time: 5h
 environment: systest
 logGroup: /my/group
-limit: 200
 ---
-fields @timestamp, @message, app
-| filter app = "my-service"
+fields @timestamp, @message
 | sort @timestamp desc
+| filter app = my-service
+| filter level in ['WARN', 'ERROR']
+| limit 200
 ```
 
 Front-matter fields:
@@ -99,9 +100,10 @@ Front-matter fields:
 | `time`        | time range (same syntax as `--time`)                                |
 | `environment` | substituted for `{env}` in log group templates                       |
 | `logGroup`    | a log group, or an array of log groups                               |
-| `limit`       | row limit                                                           |
 
-CLI flags always win over front-matter, and front-matter wins over the repo defaults in `settings.toml`.
+CLI flags always win over front-matter, and front-matter wins over the repo defaults in `settings.toml`. The result `limit` belongs in the query body itself (`| limit 200`), not the front-matter.
+
+Pass `--clear` to `query` to overwrite the current file with a fresh default template before opening the editor.
 
 ## Time-range syntax
 

--- a/cloudwatch-insights/README.md
+++ b/cloudwatch-insights/README.md
@@ -1,6 +1,6 @@
 # cloudwatch-insights
 
-Download logs from [AWS CloudWatch Logs Insights](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/AnalyzingLogData.html) from the command line, with a flexible time-range syntax.
+Download logs from [AWS CloudWatch Logs Insights](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/AnalyzingLogData.html) from the command line, with a flexible time-range syntax and per-git-repository defaults.
 
 ## Requirements
 
@@ -9,11 +9,15 @@ Download logs from [AWS CloudWatch Logs Insights](https://docs.aws.amazon.com/Am
 
 ## Installation
 
+Install globally using pnpm:
+
 ```sh
 pnpm link --global
 ```
 
-This builds the TypeScript source and installs the `cloudwatch-insights` command globally.
+This builds the TypeScript source and installs the `cloudwatch-insights` command on your `PATH`. After installation you can run `cloudwatch-insights` from anywhere.
+
+> `pnpm install -g .` is broken in pnpm v10, so use `pnpm link --global`.
 
 ## Usage
 
@@ -34,12 +38,11 @@ cloudwatch-insights -g /aws/lambda/my-func -t 13.00-13.01 \
 # Millisecond granularity
 cloudwatch-insights -g /my/group -t 09:15:00.000-09:15:00.500
 
-# A natural-language time range on a named day
+# A time range on a named day
 cloudwatch-insights -g /my/group -t "yesterday 17-18"
 
-# Multiple log groups, JSON output, read query from a file
-cloudwatch-insights -g /api/prod -g /api/staging -t 30m \
-  -f query.txt -o json
+# No -g needed when there's a matching config section — just supply --environment
+cloudwatch-insights -t 30m -e systest
 ```
 
 ### Time-range syntax
@@ -57,13 +60,49 @@ The `-t / --time` flag accepts, in order of precedence:
 
 Times use `.` or `:` as the sub-separator. Milliseconds are introduced with a `.` after the seconds (e.g. `09:15:00.500`).
 
+### Per-repository defaults (`settings.toml`)
+
+The tool detects the git repository you're running it from (via `git rev-parse --show-toplevel`) and looks up a section keyed by the repo's directory name in:
+
+```
+~/.config/cloudwatch-insights/settings.toml
+```
+
+Overridable with `$XDG_CONFIG_HOME` or the explicit `$CLOUDWATCH_INSIGHTS_CONFIG` env var.
+
+```toml
+# settings.toml
+[installer-notification]
+group = "/{env}/team-icc"
+app   = "installer-notification"
+
+[another-repo]
+group = "/prod/another"
+```
+
+Fields:
+
+- `group` — log group used when `--log-group` is not given. The literal string `{env}` is substituted with the value of `--environment`.
+- `app` — if neither `--query` nor `--query-file` is given, the default query becomes:
+  ```
+  fields @timestamp, @message, app | filter app = "<app>" | sort @timestamp desc
+  ```
+
+### `--environment`
+
+```
+-e, --environment <env>      systest | uat | prod
+```
+
+Substituted into `{env}` in the log group template (either from config or from `--log-group`). Required whenever the template contains `{env}`.
+
 ### Output formats
 
 - `ndjson` (default) — one JSON object per row, one row per line.
 - `json` — a pretty-printed JSON array.
 - `tsv` — tab-separated values with a header row (`@ptr` is omitted).
 
-Progress (query status, row counts, byte totals) is written to stderr so piping the data side is safe. Use `--quiet` to silence it.
+Progress (query status, row counts, byte totals) is written to stderr so piping stdout is safe. Use `--quiet` to silence it.
 
 ### Credentials and region
 
@@ -77,7 +116,7 @@ Standard AWS SDK resolution applies:
 
 ```sh
 pnpm install
-pnpm build   # compile TypeScript to dist/
-pnpm dev -- -g /my/group -t 5h   # run directly from src/ via tsx
-pnpm test    # run the time-range parser tests
+pnpm build                         # compile TypeScript to dist/
+pnpm dev -- -g /my/group -t 5h     # run directly from src/ via tsx
+pnpm test                          # time-range + config tests
 ```

--- a/cloudwatch-insights/README.md
+++ b/cloudwatch-insights/README.md
@@ -1,0 +1,83 @@
+# cloudwatch-insights
+
+Download logs from [AWS CloudWatch Logs Insights](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/AnalyzingLogData.html) from the command line, with a flexible time-range syntax.
+
+## Requirements
+
+- [Node.js](https://nodejs.org) (v18+)
+- AWS credentials available through the standard SDK chain (env vars, `~/.aws/credentials`, SSO, IMDS, …)
+
+## Installation
+
+```sh
+pnpm link --global
+```
+
+This builds the TypeScript source and installs the `cloudwatch-insights` command globally.
+
+## Usage
+
+```sh
+cloudwatch-insights -g <log-group> -t <time-range> [-q '<insights query>']
+```
+
+### Examples
+
+```sh
+# Last 5 hours of a default query (fields @timestamp, @message | sort @timestamp desc)
+cloudwatch-insights -g /aws/lambda/my-func -t 5h
+
+# A specific minute today, with a custom query
+cloudwatch-insights -g /aws/lambda/my-func -t 13.00-13.01 \
+  -q 'fields @timestamp, @message | filter @message like /ERROR/'
+
+# Millisecond granularity
+cloudwatch-insights -g /my/group -t 09:15:00.000-09:15:00.500
+
+# A natural-language time range on a named day
+cloudwatch-insights -g /my/group -t "yesterday 17-18"
+
+# Multiple log groups, JSON output, read query from a file
+cloudwatch-insights -g /api/prod -g /api/staging -t 30m \
+  -f query.txt -o json
+```
+
+### Time-range syntax
+
+The `-t / --time` flag accepts, in order of precedence:
+
+| Form | Examples | Meaning |
+|------|----------|---------|
+| Relative duration | `5h`, `30m`, `45s`, `500ms`, `2d`, `1w` | Last N units up to now |
+| Day keyword + time range | `yesterday 17-18`, `today 13.00-13.01.30` | Range on a named day |
+| Bare day keyword | `today`, `yesterday` | Entire day (local time) |
+| Time-only range | `13.00-13.01`, `13:00-13:01`, `09.15.30.000-09.15.30.500` | Range on today (local time). Wraps past midnight. |
+| Explicit ISO range | `2026-04-22T13:00:00Z/2026-04-22T14:00:00Z` | Separator `/`, `..`, or ` to ` |
+| Natural language | `"last Monday 9am to 5pm"` | Parsed by [chrono-node](https://github.com/wanasit/chrono) as a fallback |
+
+Times use `.` or `:` as the sub-separator. Milliseconds are introduced with a `.` after the seconds (e.g. `09:15:00.500`).
+
+### Output formats
+
+- `ndjson` (default) — one JSON object per row, one row per line.
+- `json` — a pretty-printed JSON array.
+- `tsv` — tab-separated values with a header row (`@ptr` is omitted).
+
+Progress (query status, row counts, byte totals) is written to stderr so piping the data side is safe. Use `--quiet` to silence it.
+
+### Credentials and region
+
+Standard AWS SDK resolution applies:
+
+- `--region` overrides `AWS_REGION` / `AWS_DEFAULT_REGION`.
+- `--profile` sets `AWS_PROFILE` for the process.
+- Otherwise the default credentials chain is used.
+
+## Development
+
+```sh
+pnpm install
+pnpm build   # compile TypeScript to dist/
+pnpm dev -- -g /my/group -t 5h   # run directly from src/ via tsx
+pnpm test    # run the time-range parser tests
+```

--- a/cloudwatch-insights/README.md
+++ b/cloudwatch-insights/README.md
@@ -70,6 +70,14 @@ The tool detects the git repository you're running it from (via `git rev-parse -
 
 Per the skagedal-tools convention, per-tool state lives under `~/.skagedal-tools/<tool-name>/`. Override the whole base directory with `$SKAGEDAL_TOOLS_HOME`, or point at an arbitrary file with `$CLOUDWATCH_INSIGHTS_CONFIG`.
 
+To open (and, if necessary, create) the settings file:
+
+```sh
+cloudwatch-insights edit-config
+```
+
+This opens the file in `$VISUAL` (falling back to `$EDITOR`). On first use the file is seeded with a commented template. When run from inside a git repository, a commented placeholder section for that repo is appended too — just uncomment the lines and fill in the values.
+
 ```toml
 # settings.toml
 [my-service]

--- a/cloudwatch-insights/README.md
+++ b/cloudwatch-insights/README.md
@@ -22,7 +22,7 @@ This builds the TypeScript source and installs the `cloudwatch-insights` command
 ## Usage
 
 ```sh
-cloudwatch-insights -g <log-group> -t <time-range> [-q '<insights query>']
+cloudwatch-insights -g <log-group> [-t <time-range>] [-q '<insights query>']
 ```
 
 ### Examples
@@ -47,7 +47,7 @@ cloudwatch-insights -t 30m -e systest
 
 ### Time-range syntax
 
-The `-t / --time` flag accepts, in order of precedence:
+The `-t / --time` flag defaults to `1h` (last hour). It accepts, in order of precedence:
 
 | Form | Examples | Meaning |
 |------|----------|---------|

--- a/cloudwatch-insights/package.json
+++ b/cloudwatch-insights/package.json
@@ -16,7 +16,8 @@
   "dependencies": {
     "@aws-sdk/client-cloudwatch-logs": "^3.650.0",
     "chrono-node": "^2.7.7",
-    "commander": "^12.1.0"
+    "commander": "^12.1.0",
+    "smol-toml": "^1.3.1"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/cloudwatch-insights/package.json
+++ b/cloudwatch-insights/package.json
@@ -18,7 +18,8 @@
     "@aws-sdk/client-cloudwatch-logs": "^3.650.0",
     "chrono-node": "^2.7.7",
     "gunshi": "^0.29.0",
-    "smol-toml": "^1.3.1"
+    "smol-toml": "^1.3.1",
+    "yaml": "^2.5.1"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/cloudwatch-insights/package.json
+++ b/cloudwatch-insights/package.json
@@ -2,6 +2,7 @@
   "name": "cloudwatch-insights",
   "version": "1.0.0",
   "description": "Download logs from AWS CloudWatch Logs Insights with a flexible time-range syntax",
+  "type": "module",
   "main": "dist/index.js",
   "bin": {
     "cloudwatch-insights": "dist/index.js"
@@ -16,7 +17,7 @@
   "dependencies": {
     "@aws-sdk/client-cloudwatch-logs": "^3.650.0",
     "chrono-node": "^2.7.7",
-    "commander": "^12.1.0",
+    "gunshi": "^0.29.0",
     "smol-toml": "^1.3.1"
   },
   "devDependencies": {

--- a/cloudwatch-insights/package.json
+++ b/cloudwatch-insights/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "cloudwatch-insights",
+  "version": "1.0.0",
+  "description": "Download logs from AWS CloudWatch Logs Insights with a flexible time-range syntax",
+  "main": "dist/index.js",
+  "bin": {
+    "cloudwatch-insights": "dist/index.js"
+  },
+  "scripts": {
+    "build": "tsc",
+    "prepare": "tsc",
+    "start": "node dist/index.js",
+    "dev": "tsx src/index.ts",
+    "test": "tsx --test test/*.test.ts"
+  },
+  "dependencies": {
+    "@aws-sdk/client-cloudwatch-logs": "^3.650.0",
+    "chrono-node": "^2.7.7",
+    "commander": "^12.1.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "tsx": "^4.19.0",
+    "typescript": "^5.5.0"
+  },
+  "packageManager": "pnpm@10.33.0"
+}

--- a/cloudwatch-insights/pnpm-lock.yaml
+++ b/cloudwatch-insights/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       commander:
         specifier: ^12.1.0
         version: 12.1.0
+      smol-toml:
+        specifier: ^1.3.1
+        version: 1.6.1
     devDependencies:
       '@types/node':
         specifier: ^22.0.0
@@ -531,6 +534,10 @@ packages:
 
   resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
+
+  smol-toml@1.6.1:
+    resolution: {integrity: sha512-dWUG8F5sIIARXih1DTaQAX4SsiTXhInKf1buxdY9DIg4ZYPZK5nGM1VRIYmEbDbsHt7USo99xSLFu5Q1IqTmsg==}
+    engines: {node: '>= 18'}
 
   strnum@2.2.3:
     resolution: {integrity: sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg==}
@@ -1325,6 +1332,8 @@ snapshots:
   path-expression-matcher@1.5.0: {}
 
   resolve-pkg-maps@1.0.0: {}
+
+  smol-toml@1.6.1: {}
 
   strnum@2.2.3: {}
 

--- a/cloudwatch-insights/pnpm-lock.yaml
+++ b/cloudwatch-insights/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       smol-toml:
         specifier: ^1.3.1
         version: 1.6.1
+      yaml:
+        specifier: ^2.5.1
+        version: 2.8.3
     devDependencies:
       '@types/node':
         specifier: ^22.0.0
@@ -557,6 +560,11 @@ packages:
 
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+  yaml@2.8.3:
+    resolution: {integrity: sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==}
+    engines: {node: '>= 14.6'}
+    hasBin: true
 
 snapshots:
 
@@ -1349,3 +1357,5 @@ snapshots:
   typescript@5.9.3: {}
 
   undici-types@6.21.0: {}
+
+  yaml@2.8.3: {}

--- a/cloudwatch-insights/pnpm-lock.yaml
+++ b/cloudwatch-insights/pnpm-lock.yaml
@@ -1,0 +1,1342 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      '@aws-sdk/client-cloudwatch-logs':
+        specifier: ^3.650.0
+        version: 3.1032.0
+      chrono-node:
+        specifier: ^2.7.7
+        version: 2.9.0
+      commander:
+        specifier: ^12.1.0
+        version: 12.1.0
+    devDependencies:
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.19.17
+      tsx:
+        specifier: ^4.19.0
+        version: 4.21.0
+      typescript:
+        specifier: ^5.5.0
+        version: 5.9.3
+
+packages:
+
+  '@aws-crypto/crc32@5.2.0':
+    resolution: {integrity: sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==}
+    engines: {node: '>=16.0.0'}
+
+  '@aws-crypto/sha256-browser@5.2.0':
+    resolution: {integrity: sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==}
+
+  '@aws-crypto/sha256-js@5.2.0':
+    resolution: {integrity: sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==}
+    engines: {node: '>=16.0.0'}
+
+  '@aws-crypto/supports-web-crypto@5.2.0':
+    resolution: {integrity: sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==}
+
+  '@aws-crypto/util@5.2.0':
+    resolution: {integrity: sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==}
+
+  '@aws-sdk/client-cloudwatch-logs@3.1032.0':
+    resolution: {integrity: sha512-pzvsXRUrlq5q0HTmpEUF07koRw1cikeWY4M5brPQimMBZx5VahiIVyacNwD1tr40rKwo72SyFDToBWSnXFVYKA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/core@3.974.1':
+    resolution: {integrity: sha512-gy/gffKz0zaHDaqRiLCdIvgHmaAL/HXuAtMcBP7euYSFx4BsbsdlfmUBJag+Gqe62z6/XuloKyQyaiH+kS3Vrg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-env@3.972.27':
+    resolution: {integrity: sha512-xfUt2CUZDC+Tf16A6roD1b4pk/nrXdkoLY3TEhv198AXDtBo5xUJP1zd0e8SmuKLN4PpIBX96OizZbmMlcI6oQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-http@3.972.29':
+    resolution: {integrity: sha512-hjNeYb6oLyHgMihra83ie0J/T2y9om3cy1qC90h9DRgvYXEoN4BCFf8bHguZjKhXunnv7YkmZRuYL5Mkk77eCA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-ini@3.972.31':
+    resolution: {integrity: sha512-PuQ7e8WYzAPpzvFcajxf8c0LqSzakVHVlKw8M0oubk8Kf347YOCCqT1seQrHs5AdZuIh2RD9LX4O+Xa5ImEBfQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-login@3.972.31':
+    resolution: {integrity: sha512-bBmWDmtSpmLOZR6a0kmowBcVL1hiL8Vlap/RXeMpFd7JbWl87YcwqL6T9LH/0oBVEZXu1dUZAtojgSuZgMO5xw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-node@3.972.32':
+    resolution: {integrity: sha512-9aj0x9hGYUondBZSD0XkksAdHhOKttFw4BWpLCeggeg40qSJxGrAP++g0GCm0VqWc1WtC/NRFiAVzPCy56vmog==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-process@3.972.27':
+    resolution: {integrity: sha512-1CZvfb1WzudWWIFAVQkd1OI/T1RxPcSvNWzNsb2BMBVsBJzBtB8dV5f2nymHVU4UqwxipdVt/DAbgdDRf33JDg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-sso@3.972.31':
+    resolution: {integrity: sha512-x8Mx18S48XMl9bEEpYwmXDTvjWGPIfDadReN37Lc099/DUrlL4Zs9T9rwwggo6DkKS1aev6v+MTUx7JTa87TZQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-web-identity@3.972.31':
+    resolution: {integrity: sha512-zfuNMIkGfjYsHis9qytYf74Bcmq6Ji9Xwf4w53baRCI/b2otTwZv3SW1uRiJ5Di7999QzRGhHZ96+eUeo3gSOA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-host-header@3.972.10':
+    resolution: {integrity: sha512-IJSsIMeVQ8MMCPbuh1AbltkFhLBLXn7aejzfX5YKT/VLDHn++Dcz8886tXckE+wQssyPUhaXrJhdakO2VilRhg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-logger@3.972.10':
+    resolution: {integrity: sha512-OOuGvvz1Dm20SjZo5oEBePFqxt5nf8AwkNDSyUHvD9/bfNASmstcYxFAHUowy4n6Io7mWUZ04JURZwSBvyQanQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-recursion-detection@3.972.11':
+    resolution: {integrity: sha512-+zz6f79Kj9V5qFK2P+D8Ehjnw4AhphAlCAsPjUqEcInA9umtSSKMrHbSagEeOIsDNuvVrH98bjRHcyQukTrhaQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-user-agent@3.972.31':
+    resolution: {integrity: sha512-L+hXN2HDomlIsWSHW5DVD7ppccCeRnlHXZ5uHG34ePTjF5bm0I1fmrJLbUGiW97xRXWryit5cjdP4Sx2FwiGog==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/nested-clients@3.996.21':
+    resolution: {integrity: sha512-Me3d/ua2lb2G0bQfFmvCeQQp3+nN6GSPqMxDmi/IQlQ8CrlpQ5C0JJHpz2AnOUkEFI0lBNrAL3Vnt29l44ndkA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/region-config-resolver@3.972.12':
+    resolution: {integrity: sha512-QQI43Mxd53nBij0pm8HXC+t4IOC6gnhhZfzxE0OATQyO6QfPV4e+aTIRRuAJKA6Nig/cR8eLwPryqYTX9ZrjAQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/token-providers@3.1032.0':
+    resolution: {integrity: sha512-n+PU8Z+gll7p3wDrH+Wo6fkt8sPrVnq30YYM6Ryga95oJlEneNMEbDHj0iqjMX3V7gaGdJo/hJWyPo4lscP+mA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/types@3.973.8':
+    resolution: {integrity: sha512-gjlAdtHMbtR9X5iIhVUvbVcy55KnznpC6bkDUWW9z915bi0ckdUr5cjf16Kp6xq0bP5HBD2xzgbL9F9Quv5vUw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/util-endpoints@3.996.7':
+    resolution: {integrity: sha512-ty4LQxN1QC+YhUP28NfEgZDEGXkyqOQy+BDriBozqHsrYO4JMgiPhfizqOGF7P+euBTZ5Ez6SKlLAMCLo8tzmw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/util-locate-window@3.965.5':
+    resolution: {integrity: sha512-WhlJNNINQB+9qtLtZJcpQdgZw3SCDCpXdUJP7cToGwHbCWCnRckGlc6Bx/OhWwIYFNAn+FIydY8SZ0QmVu3xTQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/util-user-agent-browser@3.972.10':
+    resolution: {integrity: sha512-FAzqXvfEssGdSIz8ejatan0bOdx1qefBWKF/gWmVBXIP1HkS7v/wjjaqrAGGKvyihrXTXW00/2/1nTJtxpXz7g==}
+
+  '@aws-sdk/util-user-agent-node@3.973.17':
+    resolution: {integrity: sha512-utF5qjjbuJQuU9VdCkWl7L87sr93cApsrD+uxGfUnlafX8iyEzJrb7EZnufjThURZVTOtelRMXrblWxpefElUg==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      aws-crt: '>=1.0.0'
+    peerDependenciesMeta:
+      aws-crt:
+        optional: true
+
+  '@aws-sdk/xml-builder@3.972.18':
+    resolution: {integrity: sha512-BMDNVG1ETXRhl1tnisQiYBef3RShJ1kfZA7x7afivTFMLirfHNTb6U71K569HNXhSXbQZsweHvSDZ6euBw8hPA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws/lambda-invoke-store@0.2.4':
+    resolution: {integrity: sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@esbuild/aix-ppc64@0.27.7':
+    resolution: {integrity: sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.27.7':
+    resolution: {integrity: sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.27.7':
+    resolution: {integrity: sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.27.7':
+    resolution: {integrity: sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.27.7':
+    resolution: {integrity: sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.27.7':
+    resolution: {integrity: sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.27.7':
+    resolution: {integrity: sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.27.7':
+    resolution: {integrity: sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.27.7':
+    resolution: {integrity: sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.27.7':
+    resolution: {integrity: sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.27.7':
+    resolution: {integrity: sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.27.7':
+    resolution: {integrity: sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.27.7':
+    resolution: {integrity: sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.27.7':
+    resolution: {integrity: sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.27.7':
+    resolution: {integrity: sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.27.7':
+    resolution: {integrity: sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.27.7':
+    resolution: {integrity: sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.27.7':
+    resolution: {integrity: sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.27.7':
+    resolution: {integrity: sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.27.7':
+    resolution: {integrity: sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.27.7':
+    resolution: {integrity: sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.27.7':
+    resolution: {integrity: sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.27.7':
+    resolution: {integrity: sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.27.7':
+    resolution: {integrity: sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.27.7':
+    resolution: {integrity: sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.27.7':
+    resolution: {integrity: sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@smithy/config-resolver@4.4.16':
+    resolution: {integrity: sha512-GFlGPNLZKrGfqWpqVb31z7hvYCA9ZscfX1buYnvvMGcRYsQQnhH+4uN6mWWflcD5jB4OXP/LBrdpukEdjl41tg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/core@3.23.15':
+    resolution: {integrity: sha512-E7GVCgsQttzfujEZb6Qep005wWf4xiL4x06apFEtzQMWYBPggZh/0cnOxPficw5cuK/YjjkehKoIN4YUaSh0UQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/credential-provider-imds@4.2.14':
+    resolution: {integrity: sha512-Au28zBN48ZAoXdooGUHemuVBrkE+Ie6RPmGNIAJsFqj33Vhb6xAgRifUydZ2aY+M+KaMAETAlKk5NC5h1G7wpg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/eventstream-codec@4.2.14':
+    resolution: {integrity: sha512-erZq0nOIpzfeZdCyzZjdJb4nVSKLUmSkaQUVkRGQTXs30gyUGeKnrYEg+Xe1W5gE3aReS7IgsvANwVPxSzY6Pw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/eventstream-serde-browser@4.2.14':
+    resolution: {integrity: sha512-8IelTCtTctWRbb+0Dcy+C0aICh1qa0qWXqgjcXDmMuCvPJRnv26hiDZoAau2ILOniki65mCPKqOQs/BaWvO4CQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/eventstream-serde-config-resolver@4.3.14':
+    resolution: {integrity: sha512-sqHiHpYRYo3FJlaIxD1J8PhbcmJAm7IuM16mVnwSkCToD7g00IBZzKuiLNMGmftULmEUX6/UAz8/NN5uMP8bVA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/eventstream-serde-node@4.2.14':
+    resolution: {integrity: sha512-Ht/8BuGlKfFTy0H3+8eEu0vdpwGztCnaLLXtpXNdQqiR7Hj4vFScU3T436vRAjATglOIPjJXronY+1WxxNLSiw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/eventstream-serde-universal@4.2.14':
+    resolution: {integrity: sha512-lWyt4T2XQZUZgK3tQ3Wn0w3XBvZsK/vjTuJl6bXbnGZBHH0ZUSONTYiK9TgjTTzU54xQr3DRFwpjmhp0oLm3gg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/fetch-http-handler@5.3.17':
+    resolution: {integrity: sha512-bXOvQzaSm6MnmLaWA1elgfQcAtN4UP3vXqV97bHuoOrHQOJiLT3ds6o9eo5bqd0TJfRFpzdGnDQdW3FACiAVdw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/hash-node@4.2.14':
+    resolution: {integrity: sha512-8ZBDY2DD4wr+GGjTpPtiglEsqr0lUP+KHqgZcWczFf6qeZ/YRjMIOoQWVQlmwu7EtxKTd8YXD8lblmYcpBIA1g==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/invalid-dependency@4.2.14':
+    resolution: {integrity: sha512-c21qJiTSb25xvvOp+H2TNZzPCngrvl5vIPqPB8zQ/DmJF4QWXO19x1dWfMJZ6wZuuWUPPm0gV8C0cU3+ifcWuw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/is-array-buffer@2.2.0':
+    resolution: {integrity: sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==}
+    engines: {node: '>=14.0.0'}
+
+  '@smithy/is-array-buffer@4.2.2':
+    resolution: {integrity: sha512-n6rQ4N8Jj4YTQO3YFrlgZuwKodf4zUFs7EJIWH86pSCWBaAtAGBFfCM7Wx6D2bBJ2xqFNxGBSrUWswT3M0VJow==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/middleware-content-length@4.2.14':
+    resolution: {integrity: sha512-xhHq7fX4/3lv5NHxLUk3OeEvl0xZ+Ek3qIbWaCL4f9JwgDZEclPBElljaZCAItdGPQl/kSM4LPMOpy1MYgprpw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/middleware-endpoint@4.4.30':
+    resolution: {integrity: sha512-qS2XqhKeXmdZ4nEQ4cOxIczSP/Y91wPAHYuRwmWDCh975B7/57uxsm5d6sisnUThn2u2FwzMdJNM7AbO1YPsPg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/middleware-retry@4.5.3':
+    resolution: {integrity: sha512-TE8dJNi6JuxzGSxMCVd3i9IEWDndCl3bmluLsBNDWok8olgj65OfkndMhl9SZ7m14c+C5SQn/PcUmrDl57rSFw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/middleware-serde@4.2.18':
+    resolution: {integrity: sha512-M6CSgnp3v4tYz9ynj2JHbA60woBZcGqEwNjTKjBsNHPV26R1ZX52+0wW8WsZU18q45jD0tw2wL22S17Ze9LpEw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/middleware-stack@4.2.14':
+    resolution: {integrity: sha512-2dvkUKLuFdKsCRmOE4Mn63co0Djtsm+JMh0bYZQupN1pJwMeE8FmQmRLLzzEMN0dnNi7CDCYYH8F0EVwWiPBeA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/node-config-provider@4.3.14':
+    resolution: {integrity: sha512-S+gFjyo/weSVL0P1b9Ts8C/CwIfNCgUPikk3sl6QVsfE/uUuO+QsF+NsE/JkpvWqqyz1wg7HFdiaZuj5CoBMRg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/node-http-handler@4.5.3':
+    resolution: {integrity: sha512-lc5jFL++x17sPhIwMWJ3YOnqmSjw/2Po6VLDlUIXvxVWRuJwRXnJ4jOBBLB0cfI5BB5ehIl02Fxr1PDvk/kxDw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/property-provider@4.2.14':
+    resolution: {integrity: sha512-WuM31CgfsnQ/10i7NYr0PyxqknD72Y5uMfUMVSniPjbEPceiTErb4eIqJQ+pdxNEAUEWrewrGjIRjVbVHsxZiQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/protocol-http@5.3.14':
+    resolution: {integrity: sha512-dN5F8kHx8RNU0r+pCwNmFZyz6ChjMkzShy/zup6MtkRmmix4vZzJdW+di7x//b1LiynIev88FM18ie+wwPcQtQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/querystring-builder@4.2.14':
+    resolution: {integrity: sha512-XYA5Z0IqTeF+5XDdh4BBmSA0HvbgVZIyv4cmOoUheDNR57K1HgBp9ukUMx3Cr3XpDHHpLBnexPE3LAtDsZkj2A==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/querystring-parser@4.2.14':
+    resolution: {integrity: sha512-hr+YyqBD23GVvRxGGrcc/oOeNlK3PzT5Fu4dzrDXxzS1LpFiuL2PQQqKPs87M79aW7ziMs+nvB3qdw77SqE7Lw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/service-error-classification@4.2.14':
+    resolution: {integrity: sha512-vVimoUnGxlx4eLLQbZImdOZFOe+Zh+5ACntv8VxZuGP72LdWu5GV3oEmCahSEReBgRJoWjypFkrehSj7BWx1HQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/shared-ini-file-loader@4.4.9':
+    resolution: {integrity: sha512-495/V2I15SHgedSJoDPD23JuSfKAp726ZI1V0wtjB07Wh7q/0tri/0e0DLefZCHgxZonrGKt/OCTpAtP1wE1kQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/signature-v4@5.3.14':
+    resolution: {integrity: sha512-1D9Y/nmlVjCeSivCbhZ7hgEpmHyY1h0GvpSZt3l0xcD9JjmjVC1CHOozS6+Gh+/ldMH8JuJ6cujObQqfayAVFA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/smithy-client@4.12.11':
+    resolution: {integrity: sha512-wzz/Wa1CH/Tlhxh0s4DQPEcXSxSVfJ59AZcUh9Gu0c6JTlKuwGf4o/3P2TExv0VbtPFt8odIBG+eQGK2+vTECg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/types@4.14.1':
+    resolution: {integrity: sha512-59b5HtSVrVR/eYNei3BUj3DCPKD/G7EtDDe7OEJE7i7FtQFugYo6MxbotS8mVJkLNVf8gYaAlEBwwtJ9HzhWSg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/url-parser@4.2.14':
+    resolution: {integrity: sha512-p06BiBigJ8bTA3MgnOfCtDUWnAMY0YfedO/GRpmc7p+wg3KW8vbXy1xwSu5ASy0wV7rRYtlfZOIKH4XqfhjSQQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-base64@4.3.2':
+    resolution: {integrity: sha512-XRH6b0H/5A3SgblmMa5ErXQ2XKhfbQB+Fm/oyLZ2O2kCUrwgg55bU0RekmzAhuwOjA9qdN5VU2BprOvGGUkOOQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-body-length-browser@4.2.2':
+    resolution: {integrity: sha512-JKCrLNOup3OOgmzeaKQwi4ZCTWlYR5H4Gm1r2uTMVBXoemo1UEghk5vtMi1xSu2ymgKVGW631e2fp9/R610ZjQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-body-length-node@4.2.3':
+    resolution: {integrity: sha512-ZkJGvqBzMHVHE7r/hcuCxlTY8pQr1kMtdsVPs7ex4mMU+EAbcXppfo5NmyxMYi2XU49eqaz56j2gsk4dHHPG/g==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-buffer-from@2.2.0':
+    resolution: {integrity: sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==}
+    engines: {node: '>=14.0.0'}
+
+  '@smithy/util-buffer-from@4.2.2':
+    resolution: {integrity: sha512-FDXD7cvUoFWwN6vtQfEta540Y/YBe5JneK3SoZg9bThSoOAC/eGeYEua6RkBgKjGa/sz6Y+DuBZj3+YEY21y4Q==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-config-provider@4.2.2':
+    resolution: {integrity: sha512-dWU03V3XUprJwaUIFVv4iOnS1FC9HnMHDfUrlNDSh4315v0cWyaIErP8KiqGVbf5z+JupoVpNM7ZB3jFiTejvQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-defaults-mode-browser@4.3.47':
+    resolution: {integrity: sha512-zlIuXai3/SHjQUQ8y3g/woLvrH573SK2wNjcDaHu5e9VOcC0JwM1MI0Sq0GZJyN3BwSUneIhpjZ18nsiz5AtQw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-defaults-mode-node@4.2.52':
+    resolution: {integrity: sha512-cQBz8g68Vnw1W2meXlkb3D/hXJU+Taiyj9P8qLJtjREEV9/Td65xi4A/H1sRQ8EIgX5qbZbvdYPKygKLholZ3w==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-endpoints@3.4.1':
+    resolution: {integrity: sha512-wMxNDZJrgS5mQV9oxCs4TWl5767VMgOfqfZ3JHyCkMtGC2ykW9iPqMvFur695Otcc5yxLG8OKO/80tsQBxrhXg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-hex-encoding@4.2.2':
+    resolution: {integrity: sha512-Qcz3W5vuHK4sLQdyT93k/rfrUwdJ8/HZ+nMUOyGdpeGA1Wxt65zYwi3oEl9kOM+RswvYq90fzkNDahPS8K0OIg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-middleware@4.2.14':
+    resolution: {integrity: sha512-1Su2vj9RYNDEv/V+2E+jXkkwGsgR7dc4sfHn9Z7ruzQHJIEni9zzw5CauvRXlFJfmgcqYP8fWa0dkh2Q2YaQyw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-retry@4.3.2':
+    resolution: {integrity: sha512-2+KTsJEwTi63NUv4uR9IQ+IFT1yu6Rf6JuoBK2WKaaJ/TRvOiOVGcXAsEqX/TQN2thR9yII21kPUJq1UV/WI2A==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-stream@4.5.23':
+    resolution: {integrity: sha512-N6on1+ngJ3RznZOnDWNveIwnTSlqxNnXuNAh7ez889ZZaRdXoNRTXKgmYOLe6dB0gCmAVtuRScE1hymQFl4hpg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-uri-escape@4.2.2':
+    resolution: {integrity: sha512-2kAStBlvq+lTXHyAZYfJRb/DfS3rsinLiwb+69SstC9Vb0s9vNWkRwpnj918Pfi85mzi42sOqdV72OLxWAISnw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-utf8@2.3.0':
+    resolution: {integrity: sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==}
+    engines: {node: '>=14.0.0'}
+
+  '@smithy/util-utf8@4.2.2':
+    resolution: {integrity: sha512-75MeYpjdWRe8M5E3AW0O4Cx3UadweS+cwdXjwYGBW5h/gxxnbeZ877sLPX/ZJA9GVTlL/qG0dXP29JWFCD1Ayw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/uuid@1.1.2':
+    resolution: {integrity: sha512-O/IEdcCUKkubz60tFbGA7ceITTAJsty+lBjNoorP4Z6XRqaFb/OjQjZODophEcuq68nKm6/0r+6/lLQ+XVpk8g==}
+    engines: {node: '>=18.0.0'}
+
+  '@types/node@22.19.17':
+    resolution: {integrity: sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==}
+
+  bowser@2.14.1:
+    resolution: {integrity: sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==}
+
+  chrono-node@2.9.0:
+    resolution: {integrity: sha512-glI4YY2Jy6JII5l3d5FN6rcrIbKSQqKPhWsIRYPK2IK8Mm4Q1ZZFdYIaDqglUNf7gNwG+kWIzTn0omzzE0VkvQ==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  commander@12.1.0:
+    resolution: {integrity: sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==}
+    engines: {node: '>=18'}
+
+  esbuild@0.27.7:
+    resolution: {integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  fast-xml-builder@1.1.5:
+    resolution: {integrity: sha512-4TJn/8FKLeslLAH3dnohXqE3QSoxkhvaMzepOIZytwJXZO69Bfz0HBdDHzOTOon6G59Zrk6VQ2bEiv1t61rfkA==}
+
+  fast-xml-parser@5.5.8:
+    resolution: {integrity: sha512-Z7Fh2nVQSb2d+poDViM063ix2ZGt9jmY1nWhPfHBOK2Hgnb/OW3P4Et3P/81SEej0J7QbWtJqxO05h8QYfK7LQ==}
+    hasBin: true
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  get-tsconfig@4.14.0:
+    resolution: {integrity: sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==}
+
+  path-expression-matcher@1.5.0:
+    resolution: {integrity: sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==}
+    engines: {node: '>=14.0.0'}
+
+  resolve-pkg-maps@1.0.0:
+    resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
+
+  strnum@2.2.3:
+    resolution: {integrity: sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg==}
+
+  tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  tsx@4.21.0:
+    resolution: {integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+snapshots:
+
+  '@aws-crypto/crc32@5.2.0':
+    dependencies:
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.973.8
+      tslib: 2.8.1
+
+  '@aws-crypto/sha256-browser@5.2.0':
+    dependencies:
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-crypto/supports-web-crypto': 5.2.0
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/util-locate-window': 3.965.5
+      '@smithy/util-utf8': 2.3.0
+      tslib: 2.8.1
+
+  '@aws-crypto/sha256-js@5.2.0':
+    dependencies:
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.973.8
+      tslib: 2.8.1
+
+  '@aws-crypto/supports-web-crypto@5.2.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@aws-crypto/util@5.2.0':
+    dependencies:
+      '@aws-sdk/types': 3.973.8
+      '@smithy/util-utf8': 2.3.0
+      tslib: 2.8.1
+
+  '@aws-sdk/client-cloudwatch-logs@3.1032.0':
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.974.1
+      '@aws-sdk/credential-provider-node': 3.972.32
+      '@aws-sdk/middleware-host-header': 3.972.10
+      '@aws-sdk/middleware-logger': 3.972.10
+      '@aws-sdk/middleware-recursion-detection': 3.972.11
+      '@aws-sdk/middleware-user-agent': 3.972.31
+      '@aws-sdk/region-config-resolver': 3.972.12
+      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/util-endpoints': 3.996.7
+      '@aws-sdk/util-user-agent-browser': 3.972.10
+      '@aws-sdk/util-user-agent-node': 3.973.17
+      '@smithy/config-resolver': 4.4.16
+      '@smithy/core': 3.23.15
+      '@smithy/eventstream-serde-browser': 4.2.14
+      '@smithy/eventstream-serde-config-resolver': 4.3.14
+      '@smithy/eventstream-serde-node': 4.2.14
+      '@smithy/fetch-http-handler': 5.3.17
+      '@smithy/hash-node': 4.2.14
+      '@smithy/invalid-dependency': 4.2.14
+      '@smithy/middleware-content-length': 4.2.14
+      '@smithy/middleware-endpoint': 4.4.30
+      '@smithy/middleware-retry': 4.5.3
+      '@smithy/middleware-serde': 4.2.18
+      '@smithy/middleware-stack': 4.2.14
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/node-http-handler': 4.5.3
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/smithy-client': 4.12.11
+      '@smithy/types': 4.14.1
+      '@smithy/url-parser': 4.2.14
+      '@smithy/util-base64': 4.3.2
+      '@smithy/util-body-length-browser': 4.2.2
+      '@smithy/util-body-length-node': 4.2.3
+      '@smithy/util-defaults-mode-browser': 4.3.47
+      '@smithy/util-defaults-mode-node': 4.2.52
+      '@smithy/util-endpoints': 3.4.1
+      '@smithy/util-middleware': 4.2.14
+      '@smithy/util-retry': 4.3.2
+      '@smithy/util-utf8': 4.2.2
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/core@3.974.1':
+    dependencies:
+      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/xml-builder': 3.972.18
+      '@smithy/core': 3.23.15
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/property-provider': 4.2.14
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/signature-v4': 5.3.14
+      '@smithy/smithy-client': 4.12.11
+      '@smithy/types': 4.14.1
+      '@smithy/util-base64': 4.3.2
+      '@smithy/util-middleware': 4.2.14
+      '@smithy/util-utf8': 4.2.2
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-env@3.972.27':
+    dependencies:
+      '@aws-sdk/core': 3.974.1
+      '@aws-sdk/types': 3.973.8
+      '@smithy/property-provider': 4.2.14
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-http@3.972.29':
+    dependencies:
+      '@aws-sdk/core': 3.974.1
+      '@aws-sdk/types': 3.973.8
+      '@smithy/fetch-http-handler': 5.3.17
+      '@smithy/node-http-handler': 4.5.3
+      '@smithy/property-provider': 4.2.14
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/smithy-client': 4.12.11
+      '@smithy/types': 4.14.1
+      '@smithy/util-stream': 4.5.23
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-ini@3.972.31':
+    dependencies:
+      '@aws-sdk/core': 3.974.1
+      '@aws-sdk/credential-provider-env': 3.972.27
+      '@aws-sdk/credential-provider-http': 3.972.29
+      '@aws-sdk/credential-provider-login': 3.972.31
+      '@aws-sdk/credential-provider-process': 3.972.27
+      '@aws-sdk/credential-provider-sso': 3.972.31
+      '@aws-sdk/credential-provider-web-identity': 3.972.31
+      '@aws-sdk/nested-clients': 3.996.21
+      '@aws-sdk/types': 3.973.8
+      '@smithy/credential-provider-imds': 4.2.14
+      '@smithy/property-provider': 4.2.14
+      '@smithy/shared-ini-file-loader': 4.4.9
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/credential-provider-login@3.972.31':
+    dependencies:
+      '@aws-sdk/core': 3.974.1
+      '@aws-sdk/nested-clients': 3.996.21
+      '@aws-sdk/types': 3.973.8
+      '@smithy/property-provider': 4.2.14
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/shared-ini-file-loader': 4.4.9
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/credential-provider-node@3.972.32':
+    dependencies:
+      '@aws-sdk/credential-provider-env': 3.972.27
+      '@aws-sdk/credential-provider-http': 3.972.29
+      '@aws-sdk/credential-provider-ini': 3.972.31
+      '@aws-sdk/credential-provider-process': 3.972.27
+      '@aws-sdk/credential-provider-sso': 3.972.31
+      '@aws-sdk/credential-provider-web-identity': 3.972.31
+      '@aws-sdk/types': 3.973.8
+      '@smithy/credential-provider-imds': 4.2.14
+      '@smithy/property-provider': 4.2.14
+      '@smithy/shared-ini-file-loader': 4.4.9
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/credential-provider-process@3.972.27':
+    dependencies:
+      '@aws-sdk/core': 3.974.1
+      '@aws-sdk/types': 3.973.8
+      '@smithy/property-provider': 4.2.14
+      '@smithy/shared-ini-file-loader': 4.4.9
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-sso@3.972.31':
+    dependencies:
+      '@aws-sdk/core': 3.974.1
+      '@aws-sdk/nested-clients': 3.996.21
+      '@aws-sdk/token-providers': 3.1032.0
+      '@aws-sdk/types': 3.973.8
+      '@smithy/property-provider': 4.2.14
+      '@smithy/shared-ini-file-loader': 4.4.9
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/credential-provider-web-identity@3.972.31':
+    dependencies:
+      '@aws-sdk/core': 3.974.1
+      '@aws-sdk/nested-clients': 3.996.21
+      '@aws-sdk/types': 3.973.8
+      '@smithy/property-provider': 4.2.14
+      '@smithy/shared-ini-file-loader': 4.4.9
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/middleware-host-header@3.972.10':
+    dependencies:
+      '@aws-sdk/types': 3.973.8
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-logger@3.972.10':
+    dependencies:
+      '@aws-sdk/types': 3.973.8
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-recursion-detection@3.972.11':
+    dependencies:
+      '@aws-sdk/types': 3.973.8
+      '@aws/lambda-invoke-store': 0.2.4
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-user-agent@3.972.31':
+    dependencies:
+      '@aws-sdk/core': 3.974.1
+      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/util-endpoints': 3.996.7
+      '@smithy/core': 3.23.15
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/types': 4.14.1
+      '@smithy/util-retry': 4.3.2
+      tslib: 2.8.1
+
+  '@aws-sdk/nested-clients@3.996.21':
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.974.1
+      '@aws-sdk/middleware-host-header': 3.972.10
+      '@aws-sdk/middleware-logger': 3.972.10
+      '@aws-sdk/middleware-recursion-detection': 3.972.11
+      '@aws-sdk/middleware-user-agent': 3.972.31
+      '@aws-sdk/region-config-resolver': 3.972.12
+      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/util-endpoints': 3.996.7
+      '@aws-sdk/util-user-agent-browser': 3.972.10
+      '@aws-sdk/util-user-agent-node': 3.973.17
+      '@smithy/config-resolver': 4.4.16
+      '@smithy/core': 3.23.15
+      '@smithy/fetch-http-handler': 5.3.17
+      '@smithy/hash-node': 4.2.14
+      '@smithy/invalid-dependency': 4.2.14
+      '@smithy/middleware-content-length': 4.2.14
+      '@smithy/middleware-endpoint': 4.4.30
+      '@smithy/middleware-retry': 4.5.3
+      '@smithy/middleware-serde': 4.2.18
+      '@smithy/middleware-stack': 4.2.14
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/node-http-handler': 4.5.3
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/smithy-client': 4.12.11
+      '@smithy/types': 4.14.1
+      '@smithy/url-parser': 4.2.14
+      '@smithy/util-base64': 4.3.2
+      '@smithy/util-body-length-browser': 4.2.2
+      '@smithy/util-body-length-node': 4.2.3
+      '@smithy/util-defaults-mode-browser': 4.3.47
+      '@smithy/util-defaults-mode-node': 4.2.52
+      '@smithy/util-endpoints': 3.4.1
+      '@smithy/util-middleware': 4.2.14
+      '@smithy/util-retry': 4.3.2
+      '@smithy/util-utf8': 4.2.2
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/region-config-resolver@3.972.12':
+    dependencies:
+      '@aws-sdk/types': 3.973.8
+      '@smithy/config-resolver': 4.4.16
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/token-providers@3.1032.0':
+    dependencies:
+      '@aws-sdk/core': 3.974.1
+      '@aws-sdk/nested-clients': 3.996.21
+      '@aws-sdk/types': 3.973.8
+      '@smithy/property-provider': 4.2.14
+      '@smithy/shared-ini-file-loader': 4.4.9
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/types@3.973.8':
+    dependencies:
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/util-endpoints@3.996.7':
+    dependencies:
+      '@aws-sdk/types': 3.973.8
+      '@smithy/types': 4.14.1
+      '@smithy/url-parser': 4.2.14
+      '@smithy/util-endpoints': 3.4.1
+      tslib: 2.8.1
+
+  '@aws-sdk/util-locate-window@3.965.5':
+    dependencies:
+      tslib: 2.8.1
+
+  '@aws-sdk/util-user-agent-browser@3.972.10':
+    dependencies:
+      '@aws-sdk/types': 3.973.8
+      '@smithy/types': 4.14.1
+      bowser: 2.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/util-user-agent-node@3.973.17':
+    dependencies:
+      '@aws-sdk/middleware-user-agent': 3.972.31
+      '@aws-sdk/types': 3.973.8
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/types': 4.14.1
+      '@smithy/util-config-provider': 4.2.2
+      tslib: 2.8.1
+
+  '@aws-sdk/xml-builder@3.972.18':
+    dependencies:
+      '@smithy/types': 4.14.1
+      fast-xml-parser: 5.5.8
+      tslib: 2.8.1
+
+  '@aws/lambda-invoke-store@0.2.4': {}
+
+  '@esbuild/aix-ppc64@0.27.7':
+    optional: true
+
+  '@esbuild/android-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/android-arm@0.27.7':
+    optional: true
+
+  '@esbuild/android-x64@0.27.7':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/darwin-x64@0.27.7':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-arm@0.27.7':
+    optional: true
+
+  '@esbuild/linux-ia32@0.27.7':
+    optional: true
+
+  '@esbuild/linux-loong64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.27.7':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-s390x@0.27.7':
+    optional: true
+
+  '@esbuild/linux-x64@0.27.7':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/sunos-x64@0.27.7':
+    optional: true
+
+  '@esbuild/win32-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/win32-ia32@0.27.7':
+    optional: true
+
+  '@esbuild/win32-x64@0.27.7':
+    optional: true
+
+  '@smithy/config-resolver@4.4.16':
+    dependencies:
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/types': 4.14.1
+      '@smithy/util-config-provider': 4.2.2
+      '@smithy/util-endpoints': 3.4.1
+      '@smithy/util-middleware': 4.2.14
+      tslib: 2.8.1
+
+  '@smithy/core@3.23.15':
+    dependencies:
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/types': 4.14.1
+      '@smithy/url-parser': 4.2.14
+      '@smithy/util-base64': 4.3.2
+      '@smithy/util-body-length-browser': 4.2.2
+      '@smithy/util-middleware': 4.2.14
+      '@smithy/util-stream': 4.5.23
+      '@smithy/util-utf8': 4.2.2
+      '@smithy/uuid': 1.1.2
+      tslib: 2.8.1
+
+  '@smithy/credential-provider-imds@4.2.14':
+    dependencies:
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/property-provider': 4.2.14
+      '@smithy/types': 4.14.1
+      '@smithy/url-parser': 4.2.14
+      tslib: 2.8.1
+
+  '@smithy/eventstream-codec@4.2.14':
+    dependencies:
+      '@aws-crypto/crc32': 5.2.0
+      '@smithy/types': 4.14.1
+      '@smithy/util-hex-encoding': 4.2.2
+      tslib: 2.8.1
+
+  '@smithy/eventstream-serde-browser@4.2.14':
+    dependencies:
+      '@smithy/eventstream-serde-universal': 4.2.14
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@smithy/eventstream-serde-config-resolver@4.3.14':
+    dependencies:
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@smithy/eventstream-serde-node@4.2.14':
+    dependencies:
+      '@smithy/eventstream-serde-universal': 4.2.14
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@smithy/eventstream-serde-universal@4.2.14':
+    dependencies:
+      '@smithy/eventstream-codec': 4.2.14
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@smithy/fetch-http-handler@5.3.17':
+    dependencies:
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/querystring-builder': 4.2.14
+      '@smithy/types': 4.14.1
+      '@smithy/util-base64': 4.3.2
+      tslib: 2.8.1
+
+  '@smithy/hash-node@4.2.14':
+    dependencies:
+      '@smithy/types': 4.14.1
+      '@smithy/util-buffer-from': 4.2.2
+      '@smithy/util-utf8': 4.2.2
+      tslib: 2.8.1
+
+  '@smithy/invalid-dependency@4.2.14':
+    dependencies:
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@smithy/is-array-buffer@2.2.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/is-array-buffer@4.2.2':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/middleware-content-length@4.2.14':
+    dependencies:
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@smithy/middleware-endpoint@4.4.30':
+    dependencies:
+      '@smithy/core': 3.23.15
+      '@smithy/middleware-serde': 4.2.18
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/shared-ini-file-loader': 4.4.9
+      '@smithy/types': 4.14.1
+      '@smithy/url-parser': 4.2.14
+      '@smithy/util-middleware': 4.2.14
+      tslib: 2.8.1
+
+  '@smithy/middleware-retry@4.5.3':
+    dependencies:
+      '@smithy/core': 3.23.15
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/service-error-classification': 4.2.14
+      '@smithy/smithy-client': 4.12.11
+      '@smithy/types': 4.14.1
+      '@smithy/util-middleware': 4.2.14
+      '@smithy/util-retry': 4.3.2
+      '@smithy/uuid': 1.1.2
+      tslib: 2.8.1
+
+  '@smithy/middleware-serde@4.2.18':
+    dependencies:
+      '@smithy/core': 3.23.15
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@smithy/middleware-stack@4.2.14':
+    dependencies:
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@smithy/node-config-provider@4.3.14':
+    dependencies:
+      '@smithy/property-provider': 4.2.14
+      '@smithy/shared-ini-file-loader': 4.4.9
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@smithy/node-http-handler@4.5.3':
+    dependencies:
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/querystring-builder': 4.2.14
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@smithy/property-provider@4.2.14':
+    dependencies:
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@smithy/protocol-http@5.3.14':
+    dependencies:
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@smithy/querystring-builder@4.2.14':
+    dependencies:
+      '@smithy/types': 4.14.1
+      '@smithy/util-uri-escape': 4.2.2
+      tslib: 2.8.1
+
+  '@smithy/querystring-parser@4.2.14':
+    dependencies:
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@smithy/service-error-classification@4.2.14':
+    dependencies:
+      '@smithy/types': 4.14.1
+
+  '@smithy/shared-ini-file-loader@4.4.9':
+    dependencies:
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@smithy/signature-v4@5.3.14':
+    dependencies:
+      '@smithy/is-array-buffer': 4.2.2
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/types': 4.14.1
+      '@smithy/util-hex-encoding': 4.2.2
+      '@smithy/util-middleware': 4.2.14
+      '@smithy/util-uri-escape': 4.2.2
+      '@smithy/util-utf8': 4.2.2
+      tslib: 2.8.1
+
+  '@smithy/smithy-client@4.12.11':
+    dependencies:
+      '@smithy/core': 3.23.15
+      '@smithy/middleware-endpoint': 4.4.30
+      '@smithy/middleware-stack': 4.2.14
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/types': 4.14.1
+      '@smithy/util-stream': 4.5.23
+      tslib: 2.8.1
+
+  '@smithy/types@4.14.1':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/url-parser@4.2.14':
+    dependencies:
+      '@smithy/querystring-parser': 4.2.14
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@smithy/util-base64@4.3.2':
+    dependencies:
+      '@smithy/util-buffer-from': 4.2.2
+      '@smithy/util-utf8': 4.2.2
+      tslib: 2.8.1
+
+  '@smithy/util-body-length-browser@4.2.2':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/util-body-length-node@4.2.3':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/util-buffer-from@2.2.0':
+    dependencies:
+      '@smithy/is-array-buffer': 2.2.0
+      tslib: 2.8.1
+
+  '@smithy/util-buffer-from@4.2.2':
+    dependencies:
+      '@smithy/is-array-buffer': 4.2.2
+      tslib: 2.8.1
+
+  '@smithy/util-config-provider@4.2.2':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/util-defaults-mode-browser@4.3.47':
+    dependencies:
+      '@smithy/property-provider': 4.2.14
+      '@smithy/smithy-client': 4.12.11
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@smithy/util-defaults-mode-node@4.2.52':
+    dependencies:
+      '@smithy/config-resolver': 4.4.16
+      '@smithy/credential-provider-imds': 4.2.14
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/property-provider': 4.2.14
+      '@smithy/smithy-client': 4.12.11
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@smithy/util-endpoints@3.4.1':
+    dependencies:
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@smithy/util-hex-encoding@4.2.2':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/util-middleware@4.2.14':
+    dependencies:
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@smithy/util-retry@4.3.2':
+    dependencies:
+      '@smithy/service-error-classification': 4.2.14
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@smithy/util-stream@4.5.23':
+    dependencies:
+      '@smithy/fetch-http-handler': 5.3.17
+      '@smithy/node-http-handler': 4.5.3
+      '@smithy/types': 4.14.1
+      '@smithy/util-base64': 4.3.2
+      '@smithy/util-buffer-from': 4.2.2
+      '@smithy/util-hex-encoding': 4.2.2
+      '@smithy/util-utf8': 4.2.2
+      tslib: 2.8.1
+
+  '@smithy/util-uri-escape@4.2.2':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/util-utf8@2.3.0':
+    dependencies:
+      '@smithy/util-buffer-from': 2.2.0
+      tslib: 2.8.1
+
+  '@smithy/util-utf8@4.2.2':
+    dependencies:
+      '@smithy/util-buffer-from': 4.2.2
+      tslib: 2.8.1
+
+  '@smithy/uuid@1.1.2':
+    dependencies:
+      tslib: 2.8.1
+
+  '@types/node@22.19.17':
+    dependencies:
+      undici-types: 6.21.0
+
+  bowser@2.14.1: {}
+
+  chrono-node@2.9.0: {}
+
+  commander@12.1.0: {}
+
+  esbuild@0.27.7:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.27.7
+      '@esbuild/android-arm': 0.27.7
+      '@esbuild/android-arm64': 0.27.7
+      '@esbuild/android-x64': 0.27.7
+      '@esbuild/darwin-arm64': 0.27.7
+      '@esbuild/darwin-x64': 0.27.7
+      '@esbuild/freebsd-arm64': 0.27.7
+      '@esbuild/freebsd-x64': 0.27.7
+      '@esbuild/linux-arm': 0.27.7
+      '@esbuild/linux-arm64': 0.27.7
+      '@esbuild/linux-ia32': 0.27.7
+      '@esbuild/linux-loong64': 0.27.7
+      '@esbuild/linux-mips64el': 0.27.7
+      '@esbuild/linux-ppc64': 0.27.7
+      '@esbuild/linux-riscv64': 0.27.7
+      '@esbuild/linux-s390x': 0.27.7
+      '@esbuild/linux-x64': 0.27.7
+      '@esbuild/netbsd-arm64': 0.27.7
+      '@esbuild/netbsd-x64': 0.27.7
+      '@esbuild/openbsd-arm64': 0.27.7
+      '@esbuild/openbsd-x64': 0.27.7
+      '@esbuild/openharmony-arm64': 0.27.7
+      '@esbuild/sunos-x64': 0.27.7
+      '@esbuild/win32-arm64': 0.27.7
+      '@esbuild/win32-ia32': 0.27.7
+      '@esbuild/win32-x64': 0.27.7
+
+  fast-xml-builder@1.1.5:
+    dependencies:
+      path-expression-matcher: 1.5.0
+
+  fast-xml-parser@5.5.8:
+    dependencies:
+      fast-xml-builder: 1.1.5
+      path-expression-matcher: 1.5.0
+      strnum: 2.2.3
+
+  fsevents@2.3.3:
+    optional: true
+
+  get-tsconfig@4.14.0:
+    dependencies:
+      resolve-pkg-maps: 1.0.0
+
+  path-expression-matcher@1.5.0: {}
+
+  resolve-pkg-maps@1.0.0: {}
+
+  strnum@2.2.3: {}
+
+  tslib@2.8.1: {}
+
+  tsx@4.21.0:
+    dependencies:
+      esbuild: 0.27.7
+      get-tsconfig: 4.14.0
+    optionalDependencies:
+      fsevents: 2.3.3
+
+  typescript@5.9.3: {}
+
+  undici-types@6.21.0: {}

--- a/cloudwatch-insights/pnpm-lock.yaml
+++ b/cloudwatch-insights/pnpm-lock.yaml
@@ -14,9 +14,9 @@ importers:
       chrono-node:
         specifier: ^2.7.7
         version: 2.9.0
-      commander:
-        specifier: ^12.1.0
-        version: 12.1.0
+      gunshi:
+        specifier: ^0.29.0
+        version: 0.29.4
       smol-toml:
         specifier: ^1.3.1
         version: 1.6.1
@@ -504,10 +504,6 @@ packages:
     resolution: {integrity: sha512-glI4YY2Jy6JII5l3d5FN6rcrIbKSQqKPhWsIRYPK2IK8Mm4Q1ZZFdYIaDqglUNf7gNwG+kWIzTn0omzzE0VkvQ==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
-  commander@12.1.0:
-    resolution: {integrity: sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==}
-    engines: {node: '>=18'}
-
   esbuild@0.27.7:
     resolution: {integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==}
     engines: {node: '>=18'}
@@ -527,6 +523,10 @@ packages:
 
   get-tsconfig@4.14.0:
     resolution: {integrity: sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==}
+
+  gunshi@0.29.4:
+    resolution: {integrity: sha512-Dstvn5GzwR2OpYKJBjYY2YHs31J4d3ht0uKQCex2bLsOD63PmQZX59rYfk5wFhG95jmrVcwbyBzBnolkVDS5kg==}
+    engines: {node: '>= 20'}
 
   path-expression-matcher@1.5.0:
     resolution: {integrity: sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==}
@@ -1281,8 +1281,6 @@ snapshots:
 
   chrono-node@2.9.0: {}
 
-  commander@12.1.0: {}
-
   esbuild@0.27.7:
     optionalDependencies:
       '@esbuild/aix-ppc64': 0.27.7
@@ -1328,6 +1326,8 @@ snapshots:
   get-tsconfig@4.14.0:
     dependencies:
       resolve-pkg-maps: 1.0.0
+
+  gunshi@0.29.4: {}
 
   path-expression-matcher@1.5.0: {}
 

--- a/cloudwatch-insights/pnpm-workspace.yaml
+++ b/cloudwatch-insights/pnpm-workspace.yaml
@@ -1,0 +1,1 @@
+minimumReleaseAge: 4320

--- a/cloudwatch-insights/src/config.ts
+++ b/cloudwatch-insights/src/config.ts
@@ -1,4 +1,4 @@
-import { readFileSync, existsSync } from "fs";
+import { readFileSync, existsSync, mkdirSync, writeFileSync, appendFileSync } from "fs";
 import { homedir } from "os";
 import { basename, dirname, join } from "path";
 import { spawnSync } from "child_process";
@@ -142,4 +142,80 @@ export function applyEnvironment(template: string, env: Environment | undefined)
 export function defaultQueryForApp(app: string): string {
   const escaped = app.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
   return `fields @timestamp, @message, app | filter app = "${escaped}" | sort @timestamp desc`;
+}
+
+const DEFAULT_SETTINGS_TEMPLATE = `# cloudwatch-insights settings
+#
+# Each section is keyed by the git repository directory name. Supported fields:
+#   group = "/{env}/my-team"    # log group template; {env} is replaced by --environment
+#   app   = "my-service"        # default query filter on the \`app\` field
+#
+# Run \`cloudwatch-insights edit-config\` from inside a git repository and a
+# commented placeholder section for that repo will be appended below.
+`;
+
+export interface EnsureResult {
+  /** True if the config file itself was created in this call. */
+  fileCreated: boolean;
+  /** Name of a section appended for the current repo, or null if none was. */
+  addedSection: string | null;
+}
+
+/**
+ * Ensure the config file exists at `path`, creating any missing parent
+ * directories and seeding the file with a commented template if absent.
+ * Additionally, if called from inside a git repository whose basename is
+ * not yet a section in the file, append a commented-out placeholder section
+ * so the user just has to uncomment and fill in values.
+ */
+export function ensureConfigFile(
+  path: string = configPath(),
+  cwd: string = process.cwd(),
+): EnsureResult {
+  let fileCreated = false;
+  if (!existsSync(path)) {
+    mkdirSync(dirname(path), { recursive: true });
+    writeFileSync(path, DEFAULT_SETTINGS_TEMPLATE, { encoding: "utf8", flag: "wx" });
+    fileCreated = true;
+  }
+
+  let addedSection: string | null = null;
+  const root = findGitRoot(cwd);
+  if (root) {
+    const name = basename(root);
+    const contents = readFileSync(path, "utf8");
+    if (!hasSectionHeader(contents, name)) {
+      const block = placeholderSection(name);
+      const prefix = endsWithNewline(contents) ? "\n" : "\n\n";
+      appendFileSync(path, prefix + block, "utf8");
+      addedSection = name;
+    }
+  }
+
+  return { fileCreated, addedSection };
+}
+
+/**
+ * Does the raw file already contain `[name]` as a section header — either
+ * as real TOML or as a commented-out placeholder? Used so we don't append
+ * a second placeholder for a repo that already has one.
+ */
+function hasSectionHeader(contents: string, name: string): boolean {
+  const escaped = name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const re = new RegExp(`^\\s*#?\\s*\\[${escaped}\\]\\s*$`, "m");
+  return re.test(contents);
+}
+
+function placeholderSection(repoName: string): string {
+  return (
+    `# ${repoName}: uncomment and fill in the values you want as defaults\n` +
+    `# when running cloudwatch-insights from this repository.\n` +
+    `# [${repoName}]\n` +
+    `# group = "/{env}/my-team"\n` +
+    `# app   = "${repoName}"\n`
+  );
+}
+
+function endsWithNewline(contents: string): boolean {
+  return contents.length === 0 || contents.endsWith("\n");
 }

--- a/cloudwatch-insights/src/config.ts
+++ b/cloudwatch-insights/src/config.ts
@@ -136,12 +136,23 @@ export function applyEnvironment(template: string, env: Environment | undefined)
 }
 
 /**
- * Build the default Insights query for an `app` filter.
- * Escapes double quotes so unusual app names don't break the query.
+ * Template used to seed a fresh `current.insights`. The placeholder
+ * `{app}` is substituted with the configured app when available; when no
+ * app is configured, the `filter app = ...` line is omitted.
  */
-export function defaultQueryForApp(app: string): string {
-  const escaped = app.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
-  return `fields @timestamp, @message, app | filter app = "${escaped}" | sort @timestamp desc`;
+export const DEFAULT_QUERY_TEMPLATE = `fields @timestamp, @message
+| sort @timestamp desc
+| filter app = {app}
+| filter level in ['WARN', 'ERROR']
+| limit 200`;
+
+export function defaultQuery(app?: string): string {
+  if (app === undefined) {
+    return DEFAULT_QUERY_TEMPLATE.split("\n")
+      .filter((line) => !line.includes("{app}"))
+      .join("\n");
+  }
+  return DEFAULT_QUERY_TEMPLATE.replace("{app}", app);
 }
 
 const DEFAULT_SETTINGS_TEMPLATE = `# cloudwatch-insights settings

--- a/cloudwatch-insights/src/config.ts
+++ b/cloudwatch-insights/src/config.ts
@@ -34,15 +34,18 @@ export class ConfigError extends Error {
 /**
  * Return the absolute path to the config file.
  *
+ * Per the skagedal-tools convention, per-tool state lives under
+ * ~/.skagedal-tools/<tool-name>/ (matches git-dirty-checker).
+ *
  * Order:
- *   1. $CLOUDWATCH_INSIGHTS_CONFIG (explicit override)
- *   2. $XDG_CONFIG_HOME/cloudwatch-insights/settings.toml
- *   3. ~/.config/cloudwatch-insights/settings.toml
+ *   1. $CLOUDWATCH_INSIGHTS_CONFIG (explicit override, mainly for tests)
+ *   2. $SKAGEDAL_TOOLS_HOME/cloudwatch-insights/settings.toml
+ *   3. ~/.skagedal-tools/cloudwatch-insights/settings.toml
  */
 export function configPath(env: NodeJS.ProcessEnv = process.env): string {
   if (env.CLOUDWATCH_INSIGHTS_CONFIG) return env.CLOUDWATCH_INSIGHTS_CONFIG;
-  const xdg = env.XDG_CONFIG_HOME || join(homedir(), ".config");
-  return join(xdg, "cloudwatch-insights", "settings.toml");
+  const base = env.SKAGEDAL_TOOLS_HOME || join(homedir(), ".skagedal-tools");
+  return join(base, "cloudwatch-insights", "settings.toml");
 }
 
 /**

--- a/cloudwatch-insights/src/config.ts
+++ b/cloudwatch-insights/src/config.ts
@@ -1,0 +1,142 @@
+import { readFileSync, existsSync } from "fs";
+import { homedir } from "os";
+import { basename, dirname, join } from "path";
+import { spawnSync } from "child_process";
+import { parse as parseToml } from "smol-toml";
+
+export type Environment = "systest" | "uat" | "prod";
+
+export const ENVIRONMENTS: readonly Environment[] = ["systest", "uat", "prod"];
+
+/**
+ * A single named section in settings.toml. Additional keys are ignored so
+ * users can extend the schema without breaking old builds of this tool.
+ */
+export interface RepoDefaults {
+  /** Log group template, may contain "{env}" placeholder. */
+  group?: string;
+  /** App name — used to build a default Insights query. */
+  app?: string;
+}
+
+export interface Settings {
+  /** Map from section name (conventionally: git repo basename) to defaults. */
+  sections: Record<string, RepoDefaults>;
+}
+
+export class ConfigError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ConfigError";
+  }
+}
+
+/**
+ * Return the absolute path to the config file.
+ *
+ * Order:
+ *   1. $CLOUDWATCH_INSIGHTS_CONFIG (explicit override)
+ *   2. $XDG_CONFIG_HOME/cloudwatch-insights/settings.toml
+ *   3. ~/.config/cloudwatch-insights/settings.toml
+ */
+export function configPath(env: NodeJS.ProcessEnv = process.env): string {
+  if (env.CLOUDWATCH_INSIGHTS_CONFIG) return env.CLOUDWATCH_INSIGHTS_CONFIG;
+  const xdg = env.XDG_CONFIG_HOME || join(homedir(), ".config");
+  return join(xdg, "cloudwatch-insights", "settings.toml");
+}
+
+/**
+ * Load settings from disk. A missing file yields empty settings rather than
+ * an error — the tool is fully usable without any config.
+ */
+export function loadSettings(path: string = configPath()): Settings {
+  if (!existsSync(path)) {
+    return { sections: {} };
+  }
+  const contents = readFileSync(path, "utf8");
+  return parseSettings(contents);
+}
+
+/** Parse a TOML string into structured settings. Exported for tests. */
+export function parseSettings(toml: string): Settings {
+  let doc: Record<string, unknown>;
+  try {
+    doc = parseToml(toml) as Record<string, unknown>;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    throw new ConfigError(`failed to parse settings.toml: ${message}`);
+  }
+
+  const sections: Record<string, RepoDefaults> = {};
+  for (const [key, value] of Object.entries(doc)) {
+    if (value && typeof value === "object" && !Array.isArray(value)) {
+      const section = value as Record<string, unknown>;
+      const defaults: RepoDefaults = {};
+      if (typeof section.group === "string") defaults.group = section.group;
+      if (typeof section.app === "string") defaults.app = section.app;
+      sections[key] = defaults;
+    }
+  }
+  return { sections };
+}
+
+/**
+ * Resolve the top-level directory of the git repository containing `cwd`.
+ * Returns null if `cwd` is not inside a git repository.
+ *
+ * We prefer shelling out to `git rev-parse` when available (handles
+ * worktrees, submodules, $GIT_DIR correctly) and fall back to walking up
+ * the tree looking for a ".git" entry.
+ */
+export function findGitRoot(cwd: string = process.cwd()): string | null {
+  const result = spawnSync("git", ["-C", cwd, "rev-parse", "--show-toplevel"], {
+    encoding: "utf8",
+  });
+  if (result.status === 0) {
+    return result.stdout.trim() || null;
+  }
+
+  let dir = cwd;
+  while (true) {
+    if (existsSync(join(dir, ".git"))) return dir;
+    const parent = dirname(dir);
+    if (parent === dir) return null;
+    dir = parent;
+  }
+}
+
+/**
+ * Pick the defaults section for the current git repo (by basename of the
+ * repo root). Returns both the section name we looked up and the defaults
+ * we found, so the caller can print a helpful message.
+ */
+export function resolveRepoDefaults(
+  settings: Settings,
+  cwd: string = process.cwd(),
+): { sectionName: string | null; defaults: RepoDefaults } {
+  const root = findGitRoot(cwd);
+  if (!root) return { sectionName: null, defaults: {} };
+  const name = basename(root);
+  const defaults = settings.sections[name] ?? {};
+  return { sectionName: name, defaults };
+}
+
+/** Substitute "{env}" in a template. Throws if the template uses {env} but none was supplied. */
+export function applyEnvironment(template: string, env: Environment | undefined): string {
+  if (!template.includes("{env}")) return template;
+  if (!env) {
+    throw new ConfigError(
+      `log group template "${template}" uses {env} — pass --environment systest|uat|prod`,
+    );
+  }
+  return template.replaceAll("{env}", env);
+}
+
+/**
+ * Build the default Insights query for an `app` filter.
+ * Escapes double quotes so unusual app names don't break the query.
+ */
+export function defaultQueryForApp(app: string): string {
+  const escaped = app.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+  return `fields @timestamp, @message, app | filter app = "${escaped}" | sort @timestamp desc`;
+}

--- a/cloudwatch-insights/src/index.ts
+++ b/cloudwatch-insights/src/index.ts
@@ -1,106 +1,188 @@
 #!/usr/bin/env node
 
 import { readFileSync } from "fs";
-import { Command, InvalidArgumentError, Option } from "commander";
+import { cli, define } from "gunshi";
 import { CloudWatchLogsClient } from "@aws-sdk/client-cloudwatch-logs";
 
-import { parseTimeRange, TimeRangeParseError } from "./time-range";
-import { runInsightsQuery, QueryRow } from "./insights";
+import { parseTimeRange, TimeRangeParseError } from "./time-range.js";
+import { runInsightsQuery, QueryRow } from "./insights.js";
 import {
   applyEnvironment,
   ConfigError,
-  configPath,
   defaultQueryForApp,
   Environment,
   ENVIRONMENTS,
   loadSettings,
   resolveRepoDefaults,
-} from "./config";
+} from "./config.js";
 
 type OutputFormat = "ndjson" | "json" | "tsv";
-
-interface CliOptions {
-  logGroup: string[];
-  time: string;
-  query?: string;
-  queryFile?: string;
-  limit?: number;
-  region?: string;
-  profile?: string;
-  environment?: Environment;
-  app?: string;
-  output: OutputFormat;
-  quiet: boolean;
-}
+const OUTPUT_FORMATS: readonly OutputFormat[] = ["ndjson", "json", "tsv"];
 
 const FALLBACK_QUERY = "fields @timestamp, @message | sort @timestamp desc";
 
-function parsePositiveInt(raw: string): number {
-  const n = parseInt(raw, 10);
-  if (!Number.isFinite(n) || n <= 0) {
-    throw new InvalidArgumentError("expected a positive integer");
+const DESCRIPTION = "Download logs from AWS CloudWatch Logs Insights.";
+
+const TIME_DESCRIPTION =
+  "time range. Examples: 5h, 30m, 500ms, 13.00-13.01, " +
+  "09:15:00.000-09:15:00.500, \"yesterday 17-18\", " +
+  "2026-04-22T13:00:00Z/2026-04-22T14:00:00Z, or natural language via chrono-node";
+
+const command = define({
+  name: "cloudwatch-insights",
+  description: DESCRIPTION,
+  args: {
+    "log-group": {
+      type: "string",
+      short: "g",
+      multiple: true,
+      description: "log group name (repeat or comma-separate; overrides config)",
+    },
+    time: {
+      type: "string",
+      short: "t",
+      required: true,
+      description: TIME_DESCRIPTION,
+    },
+    query: {
+      type: "string",
+      short: "q",
+      description: "CloudWatch Insights query string",
+    },
+    "query-file": {
+      type: "string",
+      short: "f",
+      description: "read query from file (use '-' for stdin)",
+    },
+    app: {
+      type: "string",
+      description: "filter by `app` field (overrides config's app)",
+    },
+    environment: {
+      type: "string",
+      short: "e",
+      description: "substituted for {env} in the log group template: systest | uat | prod",
+    },
+    limit: {
+      type: "number",
+      short: "l",
+      description: "maximum number of rows to return",
+    },
+    region: {
+      type: "string",
+      short: "r",
+      description: "AWS region (overrides AWS_REGION)",
+    },
+    profile: {
+      type: "string",
+      description: "AWS profile (sets AWS_PROFILE)",
+    },
+    output: {
+      type: "string",
+      short: "o",
+      default: "ndjson",
+      description: "output format: ndjson | json | tsv",
+    },
+    quiet: {
+      type: "boolean",
+      default: false,
+      description: "suppress progress output on stderr",
+    },
+  },
+  run: async (ctx) => {
+    await runCommand(ctx.values);
+  },
+});
+
+interface Values {
+  "log-group"?: string[];
+  time: string;
+  query?: string;
+  "query-file"?: string;
+  app?: string;
+  environment?: string;
+  limit?: number;
+  region?: string;
+  profile?: string;
+  output: string;
+  quiet: boolean;
+}
+
+async function runCommand(raw: Record<string, unknown>): Promise<void> {
+  const values = raw as unknown as Values;
+
+  const output = validateChoice("output", values.output, OUTPUT_FORMATS) as OutputFormat;
+  const environment = values.environment
+    ? (validateChoice("environment", values.environment, ENVIRONMENTS) as Environment)
+    : undefined;
+  const logGroupsRaw = flatten((values["log-group"] ?? []).map((s) => s.split(",")));
+  if (values.limit !== undefined && (!Number.isFinite(values.limit) || values.limit <= 0)) {
+    fail("--limit must be a positive integer", 2);
   }
-  return n;
-}
 
-function parseOutput(raw: string): OutputFormat {
-  if (raw !== "ndjson" && raw !== "json" && raw !== "tsv") {
-    throw new InvalidArgumentError(`unknown output format: ${raw}`);
+  let range;
+  try {
+    range = parseTimeRange(values.time);
+  } catch (err) {
+    if (err instanceof TimeRangeParseError) fail(err.message, 2);
+    throw err;
   }
-  return raw;
-}
 
-function buildProgram(): Command {
-  const program = new Command();
-  program
-    .name("cloudwatch-insights")
-    .description(
-      "Download logs from AWS CloudWatch Logs Insights.\n\n" +
-        "Time range examples:\n" +
-        "  5h                                last 5 hours\n" +
-        "  30m                               last 30 minutes\n" +
-        "  500ms                             last 500 milliseconds\n" +
-        "  13.00-13.01                       time range today\n" +
-        "  09:15:00.000-09:15:00.500         millisecond precision today\n" +
-        "  yesterday 17-18                   time range on a named day\n" +
-        "  2026-04-22T13:00:00Z/2026-04-22T14:00:00Z   explicit ISO range\n" +
-        "  \"last Monday 9am to 5pm\"          natural language (chrono-node)\n\n" +
-        "Defaults are read per git repository from ~/.config/cloudwatch-insights/settings.toml.\n" +
-        'Example: [my-repo]\n         group = "/{env}/team-icc"\n         app   = "installer-notification"\n',
-    )
-    .option(
-      "-g, --log-group <name...>",
-      "log group name (repeat or comma-separate for multiple; overrides config)",
-      (value: string, previous: string[] = []) =>
-        previous.concat(value.split(",").map((s) => s.trim()).filter(Boolean)),
-      [] as string[],
-    )
-    .requiredOption("-t, --time <range>", "time range (see examples above)")
-    .option("-q, --query <string>", "CloudWatch Insights query string")
-    .option("-f, --query-file <path>", "read query from file (use '-' for stdin)")
-    .option("--app <name>", "filter by `app` field (overrides config's app)")
-    .addOption(
-      new Option(
-        "-e, --environment <env>",
-        "substituted for {env} in the log group template",
-      ).choices([...ENVIRONMENTS]),
-    )
-    .option<number>("-l, --limit <n>", "maximum number of rows to return", parsePositiveInt)
-    .option("-r, --region <region>", "AWS region (overrides AWS_REGION)")
-    .option("--profile <name>", "AWS profile (sets AWS_PROFILE)")
-    .option<OutputFormat>(
-      "-o, --output <format>",
-      "output format: ndjson, json, tsv",
-      parseOutput,
-      "ndjson" as OutputFormat,
-    )
-    .option("--quiet", "suppress progress output on stderr", false);
-  return program;
-}
+  let plan: ResolvedPlan;
+  try {
+    plan = resolvePlan({
+      logGroupsRaw,
+      query: values.query,
+      queryFile: values["query-file"],
+      app: values.app,
+      environment,
+    });
+  } catch (err) {
+    if (err instanceof ConfigError || err instanceof Error) fail(err.message, 2);
+    throw err;
+  }
 
-function readQueryFile(path: string): string {
-  const source = path === "-" ? 0 : path;
-  return readFileSync(source, "utf8");
+  if (values.profile) {
+    process.env.AWS_PROFILE = values.profile;
+  }
+
+  const client = new CloudWatchLogsClient({
+    region: values.region ?? process.env.AWS_REGION,
+  });
+
+  if (!values.quiet) {
+    process.stderr.write(
+      `Querying ${plan.logGroups.length} log group(s) from ${range.startTime.toISOString()} ` +
+        `to ${range.endTime.toISOString()}\n`,
+    );
+    process.stderr.write(`  log groups: ${plan.logGroups.join(", ")} (${plan.source.logGroups})\n`);
+    process.stderr.write(`  query source: ${plan.source.query}\n`);
+  }
+
+  let lastStatus = "";
+  const result = await runInsightsQuery({
+    client,
+    logGroups: plan.logGroups,
+    queryString: plan.query,
+    startTime: range.startTime,
+    endTime: range.endTime,
+    limit: values.limit,
+    onStatus: (status) => {
+      if (values.quiet || status === lastStatus) return;
+      lastStatus = String(status);
+      process.stderr.write(`  status: ${status}\n`);
+    },
+  });
+
+  renderRows(result.rows, output);
+
+  if (!values.quiet && result.statistics) {
+    const { recordsMatched, recordsScanned, bytesScanned } = result.statistics;
+    process.stderr.write(
+      `Done. ${result.rows.length} rows returned ` +
+        `(matched=${recordsMatched ?? "?"} scanned=${recordsScanned ?? "?"} bytes=${bytesScanned ?? "?"}).\n`,
+    );
+  }
 }
 
 interface ResolvedPlan {
@@ -112,19 +194,27 @@ interface ResolvedPlan {
   };
 }
 
-function resolvePlan(options: CliOptions): ResolvedPlan {
-  if (options.query && options.queryFile) {
+interface ResolveArgs {
+  logGroupsRaw: string[];
+  query: string | undefined;
+  queryFile: string | undefined;
+  app: string | undefined;
+  environment: Environment | undefined;
+}
+
+function resolvePlan(args: ResolveArgs): ResolvedPlan {
+  if (args.query && args.queryFile) {
     throw new Error("--query and --query-file are mutually exclusive");
   }
 
   const settings = loadSettings();
   const { defaults, sectionName } = resolveRepoDefaults(settings);
 
-  let logGroups = options.logGroup;
+  let logGroups = args.logGroupsRaw.map((s) => s.trim()).filter(Boolean);
   let logGroupsSource: "cli" | "config" = "cli";
   if (logGroups.length === 0) {
     if (defaults.group) {
-      logGroups = [applyEnvironment(defaults.group, options.environment)];
+      logGroups = [applyEnvironment(defaults.group, args.environment)];
       logGroupsSource = "config";
     } else {
       throw new Error(
@@ -133,20 +223,21 @@ function resolvePlan(options: CliOptions): ResolvedPlan {
           : "no --log-group given, and no matching config section was found",
       );
     }
-  } else if (options.environment) {
-    logGroups = logGroups.map((g) => applyEnvironment(g, options.environment));
+  } else if (args.environment) {
+    logGroups = logGroups.map((g) => applyEnvironment(g, args.environment));
   }
 
   let query: string;
   let querySource: ResolvedPlan["source"]["query"];
-  if (options.query) {
-    query = options.query;
+  if (args.query) {
+    query = args.query;
     querySource = "cli";
-  } else if (options.queryFile) {
-    query = readQueryFile(options.queryFile);
+  } else if (args.queryFile) {
+    const source = args.queryFile === "-" ? 0 : args.queryFile;
+    query = readFileSync(source, "utf8");
     querySource = "query-file";
   } else {
-    const app = options.app ?? defaults.app;
+    const app = args.app ?? defaults.app;
     if (app) {
       query = defaultQueryForApp(app);
       querySource = "config-app";
@@ -205,81 +296,37 @@ function escapeTsv(value: string): string {
   return value.replace(/\t/g, " ").replace(/\r?\n/g, " ");
 }
 
-async function main(): Promise<void> {
-  const program = buildProgram();
-  program.parse(process.argv);
-  const options = program.opts<CliOptions>();
-
-  let range;
-  try {
-    range = parseTimeRange(options.time);
-  } catch (err) {
-    if (err instanceof TimeRangeParseError) {
-      process.stderr.write(`error: ${err.message}\n`);
-      process.exit(2);
-    }
-    throw err;
+function validateChoice<T extends string>(
+  name: string,
+  value: unknown,
+  choices: readonly T[],
+): T {
+  if (typeof value !== "string" || !choices.includes(value as T)) {
+    fail(`--${name} must be one of: ${choices.join(", ")} (got ${JSON.stringify(value)})`, 2);
   }
-
-  let plan: ResolvedPlan;
-  try {
-    plan = resolvePlan(options);
-  } catch (err) {
-    if (err instanceof ConfigError || err instanceof Error) {
-      process.stderr.write(`error: ${err.message}\n`);
-      process.exit(2);
-    }
-    throw err;
-  }
-
-  if (options.profile) {
-    process.env.AWS_PROFILE = options.profile;
-  }
-
-  const client = new CloudWatchLogsClient({
-    region: options.region ?? process.env.AWS_REGION,
-  });
-
-  if (!options.quiet) {
-    process.stderr.write(
-      `Querying ${plan.logGroups.length} log group(s) from ${range.startTime.toISOString()} ` +
-        `to ${range.endTime.toISOString()}\n`,
-    );
-    process.stderr.write(`  log groups: ${plan.logGroups.join(", ")} (${plan.source.logGroups})\n`);
-    process.stderr.write(`  query source: ${plan.source.query}\n`);
-  }
-
-  let lastStatus = "";
-  const result = await runInsightsQuery({
-    client,
-    logGroups: plan.logGroups,
-    queryString: plan.query,
-    startTime: range.startTime,
-    endTime: range.endTime,
-    limit: options.limit,
-    onStatus: (status) => {
-      if (options.quiet || status === lastStatus) return;
-      lastStatus = String(status);
-      process.stderr.write(`  status: ${status}\n`);
-    },
-  });
-
-  renderRows(result.rows, options.output);
-
-  if (!options.quiet && result.statistics) {
-    const { recordsMatched, recordsScanned, bytesScanned } = result.statistics;
-    process.stderr.write(
-      `Done. ${result.rows.length} rows returned ` +
-        `(matched=${recordsMatched ?? "?"} scanned=${recordsScanned ?? "?"} bytes=${bytesScanned ?? "?"}).\n`,
-    );
-  }
+  return value as T;
 }
 
-// Exported so the config file path is easy to discover from --help-ish commands.
-export { configPath };
+function flatten<T>(arrays: T[][]): T[] {
+  const out: T[] = [];
+  for (const a of arrays) out.push(...a);
+  return out;
+}
 
-main().catch((err: unknown) => {
+function fail(message: string, code = 1): never {
+  process.stderr.write(`error: ${message}\n`);
+  process.exit(code);
+}
+
+try {
+  await cli(process.argv.slice(2), command, {
+    name: "cloudwatch-insights",
+    version: "1.0.0",
+    description: DESCRIPTION,
+    renderHeader: null,
+  });
+} catch (err) {
   const message = err instanceof Error ? err.message : String(err);
   process.stderr.write(`error: ${message}\n`);
   process.exit(1);
-});
+}

--- a/cloudwatch-insights/src/index.ts
+++ b/cloudwatch-insights/src/index.ts
@@ -16,8 +16,8 @@ import {
   resolveRepoDefaults,
 } from "./config.js";
 
-type OutputFormat = "ndjson" | "json" | "tsv";
-const OUTPUT_FORMATS: readonly OutputFormat[] = ["ndjson", "json", "tsv"];
+type OutputFormat = "jsonl" | "json";
+const OUTPUT_FORMATS: readonly OutputFormat[] = ["jsonl", "json"];
 
 const FALLBACK_QUERY = "fields @timestamp, @message | sort @timestamp desc";
 
@@ -80,8 +80,8 @@ const command = define({
     output: {
       type: "string",
       short: "o",
-      default: "ndjson",
-      description: "output format: ndjson | json | tsv",
+      default: "jsonl",
+      description: "output format: jsonl | json",
     },
     quiet: {
       type: "boolean",
@@ -256,7 +256,7 @@ function resolvePlan(args: ResolveArgs): ResolvedPlan {
 
 function renderRows(rows: QueryRow[], format: OutputFormat): void {
   switch (format) {
-    case "ndjson":
+    case "jsonl":
       for (const row of rows) {
         process.stdout.write(JSON.stringify(row) + "\n");
       }
@@ -264,36 +264,7 @@ function renderRows(rows: QueryRow[], format: OutputFormat): void {
     case "json":
       process.stdout.write(JSON.stringify(rows, null, 2) + "\n");
       break;
-    case "tsv": {
-      if (rows.length === 0) return;
-      const columns = collectColumns(rows);
-      process.stdout.write(columns.join("\t") + "\n");
-      for (const row of rows) {
-        const line = columns.map((c) => escapeTsv(row[c] ?? "")).join("\t");
-        process.stdout.write(line + "\n");
-      }
-      break;
-    }
   }
-}
-
-function collectColumns(rows: QueryRow[]): string[] {
-  const seen = new Set<string>();
-  const order: string[] = [];
-  for (const row of rows) {
-    for (const key of Object.keys(row)) {
-      if (key === "@ptr") continue;
-      if (!seen.has(key)) {
-        seen.add(key);
-        order.push(key);
-      }
-    }
-  }
-  return order;
-}
-
-function escapeTsv(value: string): string {
-  return value.replace(/\t/g, " ").replace(/\r?\n/g, " ");
 }
 
 function validateChoice<T extends string>(

--- a/cloudwatch-insights/src/index.ts
+++ b/cloudwatch-insights/src/index.ts
@@ -1,11 +1,21 @@
 #!/usr/bin/env node
 
 import { readFileSync } from "fs";
-import { Command, InvalidArgumentError } from "commander";
+import { Command, InvalidArgumentError, Option } from "commander";
 import { CloudWatchLogsClient } from "@aws-sdk/client-cloudwatch-logs";
 
 import { parseTimeRange, TimeRangeParseError } from "./time-range";
 import { runInsightsQuery, QueryRow } from "./insights";
+import {
+  applyEnvironment,
+  ConfigError,
+  configPath,
+  defaultQueryForApp,
+  Environment,
+  ENVIRONMENTS,
+  loadSettings,
+  resolveRepoDefaults,
+} from "./config";
 
 type OutputFormat = "ndjson" | "json" | "tsv";
 
@@ -17,11 +27,13 @@ interface CliOptions {
   limit?: number;
   region?: string;
   profile?: string;
+  environment?: Environment;
+  app?: string;
   output: OutputFormat;
   quiet: boolean;
 }
 
-const DEFAULT_QUERY = "fields @timestamp, @message | sort @timestamp desc";
+const FALLBACK_QUERY = "fields @timestamp, @message | sort @timestamp desc";
 
 function parsePositiveInt(raw: string): number {
   const n = parseInt(raw, 10);
@@ -45,24 +57,34 @@ function buildProgram(): Command {
     .description(
       "Download logs from AWS CloudWatch Logs Insights.\n\n" +
         "Time range examples:\n" +
-        '  5h                                last 5 hours\n' +
-        '  30m                               last 30 minutes\n' +
-        '  500ms                             last 500 milliseconds\n' +
-        '  13.00-13.01                       time range today\n' +
-        '  09:15:00.000-09:15:00.500         millisecond precision today\n' +
-        '  yesterday 17-18                   time range on a named day\n' +
-        '  2026-04-22T13:00:00Z/2026-04-22T14:00:00Z   explicit ISO range\n' +
-        '  "last Monday 9am to 5pm"          natural language (chrono-node)\n',
+        "  5h                                last 5 hours\n" +
+        "  30m                               last 30 minutes\n" +
+        "  500ms                             last 500 milliseconds\n" +
+        "  13.00-13.01                       time range today\n" +
+        "  09:15:00.000-09:15:00.500         millisecond precision today\n" +
+        "  yesterday 17-18                   time range on a named day\n" +
+        "  2026-04-22T13:00:00Z/2026-04-22T14:00:00Z   explicit ISO range\n" +
+        "  \"last Monday 9am to 5pm\"          natural language (chrono-node)\n\n" +
+        "Defaults are read per git repository from ~/.config/cloudwatch-insights/settings.toml.\n" +
+        'Example: [my-repo]\n         group = "/{env}/team-icc"\n         app   = "installer-notification"\n',
     )
-    .requiredOption(
+    .option(
       "-g, --log-group <name...>",
-      "log group name (repeat or comma-separate to query multiple)",
-      (value: string, previous: string[] = []) => previous.concat(value.split(",").map((s) => s.trim()).filter(Boolean)),
+      "log group name (repeat or comma-separate for multiple; overrides config)",
+      (value: string, previous: string[] = []) =>
+        previous.concat(value.split(",").map((s) => s.trim()).filter(Boolean)),
       [] as string[],
     )
     .requiredOption("-t, --time <range>", "time range (see examples above)")
     .option("-q, --query <string>", "CloudWatch Insights query string")
     .option("-f, --query-file <path>", "read query from file (use '-' for stdin)")
+    .option("--app <name>", "filter by `app` field (overrides config's app)")
+    .addOption(
+      new Option(
+        "-e, --environment <env>",
+        "substituted for {env} in the log group template",
+      ).choices([...ENVIRONMENTS]),
+    )
     .option<number>("-l, --limit <n>", "maximum number of rows to return", parsePositiveInt)
     .option("-r, --region <region>", "AWS region (overrides AWS_REGION)")
     .option("--profile <name>", "AWS profile (sets AWS_PROFILE)")
@@ -76,16 +98,69 @@ function buildProgram(): Command {
   return program;
 }
 
-function resolveQuery(options: CliOptions): string {
+function readQueryFile(path: string): string {
+  const source = path === "-" ? 0 : path;
+  return readFileSync(source, "utf8");
+}
+
+interface ResolvedPlan {
+  logGroups: string[];
+  query: string;
+  source: {
+    logGroups: "cli" | "config";
+    query: "cli" | "query-file" | "config-app" | "default";
+  };
+}
+
+function resolvePlan(options: CliOptions): ResolvedPlan {
   if (options.query && options.queryFile) {
     throw new Error("--query and --query-file are mutually exclusive");
   }
-  if (options.query) return options.query;
-  if (options.queryFile) {
-    const source = options.queryFile === "-" ? 0 : options.queryFile;
-    return readFileSync(source, "utf8");
+
+  const settings = loadSettings();
+  const { defaults, sectionName } = resolveRepoDefaults(settings);
+
+  let logGroups = options.logGroup;
+  let logGroupsSource: "cli" | "config" = "cli";
+  if (logGroups.length === 0) {
+    if (defaults.group) {
+      logGroups = [applyEnvironment(defaults.group, options.environment)];
+      logGroupsSource = "config";
+    } else {
+      throw new Error(
+        sectionName
+          ? `no --log-group given, and config section [${sectionName}] has no "group"`
+          : "no --log-group given, and no matching config section was found",
+      );
+    }
+  } else if (options.environment) {
+    logGroups = logGroups.map((g) => applyEnvironment(g, options.environment));
   }
-  return DEFAULT_QUERY;
+
+  let query: string;
+  let querySource: ResolvedPlan["source"]["query"];
+  if (options.query) {
+    query = options.query;
+    querySource = "cli";
+  } else if (options.queryFile) {
+    query = readQueryFile(options.queryFile);
+    querySource = "query-file";
+  } else {
+    const app = options.app ?? defaults.app;
+    if (app) {
+      query = defaultQueryForApp(app);
+      querySource = "config-app";
+    } else {
+      query = FALLBACK_QUERY;
+      querySource = "default";
+    }
+  }
+
+  return {
+    logGroups,
+    query,
+    source: { logGroups: logGroupsSource, query: querySource },
+  };
 }
 
 function renderRows(rows: QueryRow[], format: OutputFormat): void {
@@ -135,13 +210,22 @@ async function main(): Promise<void> {
   program.parse(process.argv);
   const options = program.opts<CliOptions>();
 
-  const query = resolveQuery(options);
-
   let range;
   try {
     range = parseTimeRange(options.time);
   } catch (err) {
     if (err instanceof TimeRangeParseError) {
+      process.stderr.write(`error: ${err.message}\n`);
+      process.exit(2);
+    }
+    throw err;
+  }
+
+  let plan: ResolvedPlan;
+  try {
+    plan = resolvePlan(options);
+  } catch (err) {
+    if (err instanceof ConfigError || err instanceof Error) {
       process.stderr.write(`error: ${err.message}\n`);
       process.exit(2);
     }
@@ -158,16 +242,18 @@ async function main(): Promise<void> {
 
   if (!options.quiet) {
     process.stderr.write(
-      `Querying ${options.logGroup.length} log group(s) from ${range.startTime.toISOString()} ` +
+      `Querying ${plan.logGroups.length} log group(s) from ${range.startTime.toISOString()} ` +
         `to ${range.endTime.toISOString()}\n`,
     );
+    process.stderr.write(`  log groups: ${plan.logGroups.join(", ")} (${plan.source.logGroups})\n`);
+    process.stderr.write(`  query source: ${plan.source.query}\n`);
   }
 
   let lastStatus = "";
   const result = await runInsightsQuery({
     client,
-    logGroups: options.logGroup,
-    queryString: query,
+    logGroups: plan.logGroups,
+    queryString: plan.query,
     startTime: range.startTime,
     endTime: range.endTime,
     limit: options.limit,
@@ -188,6 +274,9 @@ async function main(): Promise<void> {
     );
   }
 }
+
+// Exported so the config file path is easy to discover from --help-ish commands.
+export { configPath };
 
 main().catch((err: unknown) => {
   const message = err instanceof Error ? err.message : String(err);

--- a/cloudwatch-insights/src/index.ts
+++ b/cloudwatch-insights/src/index.ts
@@ -27,7 +27,7 @@ const FALLBACK_QUERY = "fields @timestamp, @message | sort @timestamp desc";
 const DESCRIPTION = "Download logs from AWS CloudWatch Logs Insights.";
 
 const TIME_DESCRIPTION =
-  "time range. Examples: 5h, 30m, 500ms, 13.00-13.01, " +
+  "time range (defaults to 1h). Examples: 5h, 30m, 500ms, 13.00-13.01, " +
   "09:15:00.000-09:15:00.500, \"yesterday 17-18\", " +
   "2026-04-22T13:00:00Z/2026-04-22T14:00:00Z, or natural language via chrono-node";
 
@@ -44,7 +44,7 @@ const command = define({
     time: {
       type: "string",
       short: "t",
-      required: true,
+      default: "1h",
       description: TIME_DESCRIPTION,
     },
     query: {

--- a/cloudwatch-insights/src/index.ts
+++ b/cloudwatch-insights/src/index.ts
@@ -1,39 +1,50 @@
 #!/usr/bin/env node
 
-import { readFileSync } from "fs";
+import { createReadStream, existsSync, readFileSync } from "fs";
 import { spawnSync } from "child_process";
+import { pipeline } from "stream/promises";
 import { cli, define } from "gunshi";
 import { CloudWatchLogsClient } from "@aws-sdk/client-cloudwatch-logs";
 
 import { parseTimeRange, TimeRangeParseError } from "./time-range.js";
-import { runInsightsQuery, QueryRow } from "./insights.js";
+import { runInsightsQuery } from "./insights.js";
 import {
   applyEnvironment,
   ConfigError,
   configPath,
-  defaultQueryForApp,
   ensureConfigFile,
   Environment,
   ENVIRONMENTS,
   loadSettings,
   resolveRepoDefaults,
 } from "./config.js";
-
-type OutputFormat = "jsonl" | "json";
-const OUTPUT_FORMATS: readonly OutputFormat[] = ["jsonl", "json"];
-
-const FALLBACK_QUERY = "fields @timestamp, @message | sort @timestamp desc";
+import {
+  currentInsightsPath,
+  ensureCurrentInsights,
+  FrontMatter,
+  latestRunPath,
+  loadQueryFile,
+  parseQueryFile,
+  runResultPath,
+  updateLatestSymlink,
+  writeResults,
+} from "./query-file.js";
 
 const DESCRIPTION = "Download logs from AWS CloudWatch Logs Insights.";
 
 const TIME_DESCRIPTION =
-  "time range (defaults to 1h). Examples: 5h, 30m, 500ms, 13.00-13.01, " +
+  "time range. Examples: 5h, 30m, 500ms, 13.00-13.01, " +
   "09:15:00.000-09:15:00.500, \"yesterday 17-18\", " +
-  "2026-04-22T13:00:00Z/2026-04-22T14:00:00Z, or natural language via chrono-node";
+  "2026-04-22T13:00:00Z/2026-04-22T14:00:00Z, or natural language via chrono-node. " +
+  "Defaults to the front-matter `time` if present, otherwise 1h.";
 
-const command = define({
-  name: "cloudwatch-insights",
-  description: DESCRIPTION,
+// ---------------------------------------------------------------------------
+// query subcommand
+// ---------------------------------------------------------------------------
+
+const queryCmd = define({
+  name: "query",
+  description: "Run a CloudWatch Logs Insights query (opens $EDITOR when no -q/-f is given)",
   args: {
     "log-group": {
       type: "string",
@@ -44,22 +55,17 @@ const command = define({
     time: {
       type: "string",
       short: "t",
-      default: "1h",
       description: TIME_DESCRIPTION,
     },
     query: {
       type: "string",
       short: "q",
-      description: "CloudWatch Insights query string",
+      description: "CloudWatch Insights query string (skips editor)",
     },
     "query-file": {
       type: "string",
       short: "f",
-      description: "read query from file (use '-' for stdin)",
-    },
-    app: {
-      type: "string",
-      description: "filter by `app` field (overrides config's app)",
+      description: "read query from file (use '-' for stdin; skips editor)",
     },
     environment: {
       type: "string",
@@ -80,12 +86,6 @@ const command = define({
       type: "string",
       description: "AWS profile (sets AWS_PROFILE)",
     },
-    output: {
-      type: "string",
-      short: "o",
-      default: "jsonl",
-      description: "output format: jsonl | json",
-    },
     quiet: {
       type: "boolean",
       default: false,
@@ -93,83 +93,75 @@ const command = define({
     },
   },
   run: async (ctx) => {
-    await runCommand(ctx.values);
+    await runQuery(ctx.values as unknown as QueryValues);
   },
 });
 
-interface Values {
+interface QueryValues {
   "log-group"?: string[];
-  time: string;
+  time?: string;
   query?: string;
   "query-file"?: string;
-  app?: string;
   environment?: string;
   limit?: number;
   region?: string;
   profile?: string;
-  output: string;
   quiet: boolean;
 }
 
-async function runCommand(raw: Record<string, unknown>): Promise<void> {
-  const values = raw as unknown as Values;
-
-  const output = validateChoice("output", values.output, OUTPUT_FORMATS) as OutputFormat;
-  const environment = values.environment
-    ? (validateChoice("environment", values.environment, ENVIRONMENTS) as Environment)
-    : undefined;
-  const logGroupsRaw = flatten((values["log-group"] ?? []).map((s) => s.split(",")));
-  if (values.limit !== undefined && (!Number.isFinite(values.limit) || values.limit <= 0)) {
-    fail("--limit must be a positive integer", 2);
+async function runQuery(values: QueryValues): Promise<void> {
+  if (values.query && values["query-file"]) {
+    fail("--query and --query-file are mutually exclusive", 2);
   }
+
+  const settings = loadSettings();
+  const { defaults, sectionName } = resolveRepoDefaults(settings);
+
+  const { queryBody, frontMatter } = await resolveQuerySource(values, defaults.app);
+
+  const environment = pickEnvironment(values.environment ?? frontMatter.environment);
+  const timeExpr = values.time ?? frontMatter.time ?? "1h";
+  const limit = values.limit ?? frontMatter.limit;
 
   let range;
   try {
-    range = parseTimeRange(values.time);
+    range = parseTimeRange(timeExpr);
   } catch (err) {
     if (err instanceof TimeRangeParseError) fail(err.message, 2);
     throw err;
   }
 
-  let plan: ResolvedPlan;
-  try {
-    plan = resolvePlan({
-      logGroupsRaw,
-      query: values.query,
-      queryFile: values["query-file"],
-      app: values.app,
-      environment,
-    });
-  } catch (err) {
-    if (err instanceof ConfigError || err instanceof Error) fail(err.message, 2);
-    throw err;
-  }
+  const logGroups = resolveLogGroups({
+    cliLogGroups: flatten((values["log-group"] ?? []).map((s) => s.split(","))),
+    frontMatterLogGroup: frontMatter.logGroup,
+    configGroupTemplate: defaults.group,
+    environment,
+    sectionName,
+  });
 
   if (values.profile) {
     process.env.AWS_PROFILE = values.profile;
   }
-
   const client = new CloudWatchLogsClient({
     region: values.region ?? process.env.AWS_REGION,
   });
 
   if (!values.quiet) {
     process.stderr.write(
-      `Querying ${plan.logGroups.length} log group(s) from ${range.startTime.toISOString()} ` +
+      `Querying ${logGroups.length} log group(s) from ${range.startTime.toISOString()} ` +
         `to ${range.endTime.toISOString()}\n`,
     );
-    process.stderr.write(`  log groups: ${plan.logGroups.join(", ")} (${plan.source.logGroups})\n`);
-    process.stderr.write(`  query source: ${plan.source.query}\n`);
+    process.stderr.write(`  log groups: ${logGroups.join(", ")}\n`);
   }
 
   let lastStatus = "";
   const result = await runInsightsQuery({
     client,
-    logGroups: plan.logGroups,
-    queryString: plan.query,
+    logGroups,
+    queryString: queryBody,
     startTime: range.startTime,
     endTime: range.endTime,
-    limit: values.limit,
+    limit,
     onStatus: (status) => {
       if (values.quiet || status === lastStatus) return;
       lastStatus = String(status);
@@ -177,108 +169,169 @@ async function runCommand(raw: Record<string, unknown>): Promise<void> {
     },
   });
 
-  renderRows(result.rows, output);
+  const outPath = runResultPath();
+  writeResults({ path: outPath, rows: result.rows });
+  const linkPath = updateLatestSymlink(outPath);
 
-  if (!values.quiet && result.statistics) {
-    const { recordsMatched, recordsScanned, bytesScanned } = result.statistics;
+  process.stdout.write(outPath + "\n");
+
+  if (!values.quiet) {
+    const { recordsMatched, recordsScanned, bytesScanned } = result.statistics ?? {};
     process.stderr.write(
-      `Done. ${result.rows.length} rows returned ` +
-        `(matched=${recordsMatched ?? "?"} scanned=${recordsScanned ?? "?"} bytes=${bytesScanned ?? "?"}).\n`,
+      `Done. ${result.rows.length} rows written (matched=${recordsMatched ?? "?"} ` +
+        `scanned=${recordsScanned ?? "?"} bytes=${bytesScanned ?? "?"}).\n`,
     );
+    process.stderr.write(`  ${linkPath} → ${outPath}\n`);
   }
 }
 
-interface ResolvedPlan {
-  logGroups: string[];
-  query: string;
-  source: {
-    logGroups: "cli" | "config";
-    query: "cli" | "query-file" | "config-app" | "default";
-  };
+interface QuerySource {
+  queryBody: string;
+  frontMatter: FrontMatter;
 }
 
-interface ResolveArgs {
-  logGroupsRaw: string[];
-  query: string | undefined;
-  queryFile: string | undefined;
-  app: string | undefined;
+async function resolveQuerySource(
+  values: QueryValues,
+  configApp: string | undefined,
+): Promise<QuerySource> {
+  if (values.query) {
+    return { queryBody: values.query, frontMatter: {} };
+  }
+  if (values["query-file"]) {
+    const source = values["query-file"] === "-" ? 0 : values["query-file"];
+    const raw = readFileSync(source, "utf8");
+    // Support front-matter in explicit files too.
+    const parsed = parseQueryFile(raw);
+    return { queryBody: parsed.body, frontMatter: parsed.frontMatter };
+  }
+
+  // Editor flow
+  const path = currentInsightsPath();
+  const seeded = ensureCurrentInsights(path, configApp);
+  if (seeded && !values.quiet) {
+    process.stderr.write(`Seeded ${path}\n`);
+  }
+  openEditor(path);
+  const parsed = loadQueryFile(path);
+  if (!parsed.body) {
+    fail(`${path} has no query body`, 2);
+  }
+  return { queryBody: parsed.body, frontMatter: parsed.frontMatter };
+}
+
+interface ResolveLogGroupsArgs {
+  cliLogGroups: string[];
+  frontMatterLogGroup: string | string[] | undefined;
+  configGroupTemplate: string | undefined;
   environment: Environment | undefined;
+  sectionName: string | null;
 }
 
-function resolvePlan(args: ResolveArgs): ResolvedPlan {
-  if (args.query && args.queryFile) {
-    throw new Error("--query and --query-file are mutually exclusive");
+function resolveLogGroups(args: ResolveLogGroupsArgs): string[] {
+  const fromCli = args.cliLogGroups.map((s) => s.trim()).filter(Boolean);
+  if (fromCli.length > 0) {
+    try {
+      return fromCli.map((g) => applyEnvironment(g, args.environment));
+    } catch (err) {
+      if (err instanceof ConfigError) fail(err.message, 2);
+      throw err;
+    }
   }
+  const fromFm = toArray(args.frontMatterLogGroup);
+  if (fromFm.length > 0) {
+    try {
+      return fromFm.map((g) => applyEnvironment(g, args.environment));
+    } catch (err) {
+      if (err instanceof ConfigError) fail(err.message, 2);
+      throw err;
+    }
+  }
+  if (args.configGroupTemplate) {
+    try {
+      return [applyEnvironment(args.configGroupTemplate, args.environment)];
+    } catch (err) {
+      if (err instanceof ConfigError) fail(err.message, 2);
+      throw err;
+    }
+  }
+  fail(
+    args.sectionName
+      ? `no log group given, and config section [${args.sectionName}] has no "group". Set it with \`cloudwatch-insights edit-config\` or pass --log-group.`
+      : "no log group given, and no matching config section was found. Pass --log-group or run `cloudwatch-insights edit-config`.",
+    2,
+  );
+}
 
-  const settings = loadSettings();
-  const { defaults, sectionName } = resolveRepoDefaults(settings);
+// ---------------------------------------------------------------------------
+// show subcommand
+// ---------------------------------------------------------------------------
 
-  let logGroups = args.logGroupsRaw.map((s) => s.trim()).filter(Boolean);
-  let logGroupsSource: "cli" | "config" = "cli";
-  if (logGroups.length === 0) {
-    if (defaults.group) {
-      logGroups = [applyEnvironment(defaults.group, args.environment)];
-      logGroupsSource = "config";
-    } else {
-      throw new Error(
-        sectionName
-          ? `no --log-group given, and config section [${sectionName}] has no "group"`
-          : "no --log-group given, and no matching config section was found",
+const showCmd = define({
+  name: "show",
+  description: "Stream the contents of latest-run.jsonl to stdout",
+  args: {},
+  run: async () => {
+    const path = latestRunPath();
+    if (!existsSync(path)) {
+      fail(`no runs found (${path} does not exist). Run \`cloudwatch-insights query\` first.`, 2);
+    }
+    await pipeline(createReadStream(path), process.stdout);
+  },
+});
+
+// ---------------------------------------------------------------------------
+// edit-config subcommand
+// ---------------------------------------------------------------------------
+
+const editConfigCmd = define({
+  name: "edit-config",
+  description: "Open settings.toml in $EDITOR, creating it (and a placeholder section for the current repo) if needed",
+  args: {},
+  run: () => {
+    const path = configPath();
+    const { fileCreated, addedSection } = ensureConfigFile(path);
+    if (fileCreated) process.stderr.write(`Created ${path}\n`);
+    if (addedSection) {
+      process.stderr.write(
+        `Added commented placeholder section [${addedSection}] for the current repository\n`,
       );
     }
-  } else if (args.environment) {
-    logGroups = logGroups.map((g) => applyEnvironment(g, args.environment));
+    openEditor(path);
+  },
+});
+
+// ---------------------------------------------------------------------------
+// shared helpers
+// ---------------------------------------------------------------------------
+
+function openEditor(path: string): void {
+  const editor = process.env.VISUAL || process.env.EDITOR;
+  if (!editor) {
+    fail("no editor set — define $EDITOR (or $VISUAL) and retry", 2);
   }
-
-  let query: string;
-  let querySource: ResolvedPlan["source"]["query"];
-  if (args.query) {
-    query = args.query;
-    querySource = "cli";
-  } else if (args.queryFile) {
-    const source = args.queryFile === "-" ? 0 : args.queryFile;
-    query = readFileSync(source, "utf8");
-    querySource = "query-file";
-  } else {
-    const app = args.app ?? defaults.app;
-    if (app) {
-      query = defaultQueryForApp(app);
-      querySource = "config-app";
-    } else {
-      query = FALLBACK_QUERY;
-      querySource = "default";
-    }
+  const parts = editor.split(/\s+/).filter(Boolean);
+  const cmd = parts[0];
+  const args = [...parts.slice(1), path];
+  const result = spawnSync(cmd, args, { stdio: "inherit" });
+  if (result.error) {
+    fail(`failed to launch editor (${editor}): ${result.error.message}`, 1);
   }
-
-  return {
-    logGroups,
-    query,
-    source: { logGroups: logGroupsSource, query: querySource },
-  };
-}
-
-function renderRows(rows: QueryRow[], format: OutputFormat): void {
-  switch (format) {
-    case "jsonl":
-      for (const row of rows) {
-        process.stdout.write(JSON.stringify(row) + "\n");
-      }
-      break;
-    case "json":
-      process.stdout.write(JSON.stringify(rows, null, 2) + "\n");
-      break;
+  if (typeof result.status === "number" && result.status !== 0) {
+    process.exit(result.status);
   }
 }
 
-function validateChoice<T extends string>(
-  name: string,
-  value: unknown,
-  choices: readonly T[],
-): T {
-  if (typeof value !== "string" || !choices.includes(value as T)) {
-    fail(`--${name} must be one of: ${choices.join(", ")} (got ${JSON.stringify(value)})`, 2);
+function pickEnvironment(raw: string | undefined): Environment | undefined {
+  if (raw === undefined) return undefined;
+  if (!ENVIRONMENTS.includes(raw as Environment)) {
+    fail(`--environment must be one of: ${ENVIRONMENTS.join(", ")} (got ${JSON.stringify(raw)})`, 2);
   }
-  return value as T;
+  return raw as Environment;
+}
+
+function toArray<T>(value: T | T[] | undefined): T[] {
+  if (value === undefined) return [];
+  return Array.isArray(value) ? value : [value];
 }
 
 function flatten<T>(arrays: T[][]): T[] {
@@ -292,59 +345,35 @@ function fail(message: string, code = 1): never {
   process.exit(code);
 }
 
-const EDIT_CONFIG_HELP =
-  "Usage: cloudwatch-insights edit-config\n\n" +
-  "Open the settings.toml in $EDITOR (or $VISUAL), creating it with a\n" +
-  "commented template if it does not yet exist.\n";
+// ---------------------------------------------------------------------------
+// main entry: unknown commands and `cloudwatch-insights` with no args both
+// fall through to this, which prints a hint.
+// ---------------------------------------------------------------------------
 
-function runEditConfig(argv: string[]): void {
-  if (argv.includes("--help") || argv.includes("-h")) {
-    process.stdout.write(EDIT_CONFIG_HELP);
-    return;
-  }
-
-  const path = configPath();
-  const { fileCreated, addedSection } = ensureConfigFile(path);
-  if (fileCreated) {
-    process.stderr.write(`Created ${path}\n`);
-  }
-  if (addedSection) {
-    process.stderr.write(`Added commented placeholder section [${addedSection}] for the current repository\n`);
-  }
-
-  const editor = process.env.VISUAL || process.env.EDITOR;
-  if (!editor) {
-    fail("no editor set — define $EDITOR (or $VISUAL) and retry", 2);
-  }
-
-  const parts = editor.split(/\s+/).filter(Boolean);
-  const cmd = parts[0];
-  const args = [...parts.slice(1), path];
-  const result = spawnSync(cmd, args, { stdio: "inherit" });
-  if (result.error) {
-    fail(`failed to launch editor (${editor}): ${result.error.message}`, 1);
-  }
-  if (typeof result.status === "number" && result.status !== 0) {
-    process.exit(result.status);
-  }
-}
-
-const argv = process.argv.slice(2);
-
-// edit-config is handled manually rather than through gunshi's subCommands,
-// because gunshi routes the first non-flag token to subcommand dispatch before
-// consuming flag values — that turns "-t 5m" into "Command not found: 5m".
-if (argv[0] === "edit-config") {
-  runEditConfig(argv.slice(1));
-  process.exit(0);
-}
+const main = define({
+  name: "cloudwatch-insights",
+  description: DESCRIPTION,
+  args: {},
+  run: () => {
+    process.stderr.write(
+      "Usage: cloudwatch-insights <query|show|edit-config>\n" +
+        "Run `cloudwatch-insights --help` for details.\n",
+    );
+    process.exit(2);
+  },
+});
 
 try {
-  await cli(argv, command, {
+  await cli(process.argv.slice(2), main, {
     name: "cloudwatch-insights",
     version: "1.0.0",
     description: DESCRIPTION,
     renderHeader: null,
+    subCommands: {
+      query: queryCmd,
+      show: showCmd,
+      "edit-config": editConfigCmd,
+    },
   });
 } catch (err) {
   const message = err instanceof Error ? err.message : String(err);

--- a/cloudwatch-insights/src/index.ts
+++ b/cloudwatch-insights/src/index.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 import { readFileSync } from "fs";
+import { spawnSync } from "child_process";
 import { cli, define } from "gunshi";
 import { CloudWatchLogsClient } from "@aws-sdk/client-cloudwatch-logs";
 
@@ -9,7 +10,9 @@ import { runInsightsQuery, QueryRow } from "./insights.js";
 import {
   applyEnvironment,
   ConfigError,
+  configPath,
   defaultQueryForApp,
+  ensureConfigFile,
   Environment,
   ENVIRONMENTS,
   loadSettings,
@@ -289,8 +292,55 @@ function fail(message: string, code = 1): never {
   process.exit(code);
 }
 
+const EDIT_CONFIG_HELP =
+  "Usage: cloudwatch-insights edit-config\n\n" +
+  "Open the settings.toml in $EDITOR (or $VISUAL), creating it with a\n" +
+  "commented template if it does not yet exist.\n";
+
+function runEditConfig(argv: string[]): void {
+  if (argv.includes("--help") || argv.includes("-h")) {
+    process.stdout.write(EDIT_CONFIG_HELP);
+    return;
+  }
+
+  const path = configPath();
+  const { fileCreated, addedSection } = ensureConfigFile(path);
+  if (fileCreated) {
+    process.stderr.write(`Created ${path}\n`);
+  }
+  if (addedSection) {
+    process.stderr.write(`Added commented placeholder section [${addedSection}] for the current repository\n`);
+  }
+
+  const editor = process.env.VISUAL || process.env.EDITOR;
+  if (!editor) {
+    fail("no editor set — define $EDITOR (or $VISUAL) and retry", 2);
+  }
+
+  const parts = editor.split(/\s+/).filter(Boolean);
+  const cmd = parts[0];
+  const args = [...parts.slice(1), path];
+  const result = spawnSync(cmd, args, { stdio: "inherit" });
+  if (result.error) {
+    fail(`failed to launch editor (${editor}): ${result.error.message}`, 1);
+  }
+  if (typeof result.status === "number" && result.status !== 0) {
+    process.exit(result.status);
+  }
+}
+
+const argv = process.argv.slice(2);
+
+// edit-config is handled manually rather than through gunshi's subCommands,
+// because gunshi routes the first non-flag token to subcommand dispatch before
+// consuming flag values — that turns "-t 5m" into "Command not found: 5m".
+if (argv[0] === "edit-config") {
+  runEditConfig(argv.slice(1));
+  process.exit(0);
+}
+
 try {
-  await cli(process.argv.slice(2), command, {
+  await cli(argv, command, {
     name: "cloudwatch-insights",
     version: "1.0.0",
     description: DESCRIPTION,

--- a/cloudwatch-insights/src/index.ts
+++ b/cloudwatch-insights/src/index.ts
@@ -25,6 +25,7 @@ import {
   latestRunPath,
   loadQueryFile,
   parseQueryFile,
+  resetCurrentInsights,
   runResultPath,
   updateLatestSymlink,
   writeResults,
@@ -86,6 +87,11 @@ const queryCmd = define({
       type: "string",
       description: "AWS profile (sets AWS_PROFILE)",
     },
+    clear: {
+      type: "boolean",
+      default: false,
+      description: "reset current.insights to the default template before opening the editor",
+    },
     quiet: {
       type: "boolean",
       default: false,
@@ -106,6 +112,7 @@ interface QueryValues {
   limit?: number;
   region?: string;
   profile?: string;
+  clear: boolean;
   quiet: boolean;
 }
 
@@ -121,7 +128,7 @@ async function runQuery(values: QueryValues): Promise<void> {
 
   const environment = pickEnvironment(values.environment ?? frontMatter.environment);
   const timeExpr = values.time ?? frontMatter.time ?? "1h";
-  const limit = values.limit ?? frontMatter.limit;
+  const limit = values.limit;
 
   let range;
   try {
@@ -207,9 +214,14 @@ async function resolveQuerySource(
 
   // Editor flow
   const path = currentInsightsPath();
-  const seeded = ensureCurrentInsights(path, configApp);
-  if (seeded && !values.quiet) {
-    process.stderr.write(`Seeded ${path}\n`);
+  if (values.clear) {
+    resetCurrentInsights(path, configApp);
+    if (!values.quiet) process.stderr.write(`Reset ${path} to default template\n`);
+  } else {
+    const seeded = ensureCurrentInsights(path, configApp);
+    if (seeded && !values.quiet) {
+      process.stderr.write(`Seeded ${path}\n`);
+    }
   }
   openEditor(path);
   const parsed = loadQueryFile(path);

--- a/cloudwatch-insights/src/index.ts
+++ b/cloudwatch-insights/src/index.ts
@@ -1,0 +1,196 @@
+#!/usr/bin/env node
+
+import { readFileSync } from "fs";
+import { Command, InvalidArgumentError } from "commander";
+import { CloudWatchLogsClient } from "@aws-sdk/client-cloudwatch-logs";
+
+import { parseTimeRange, TimeRangeParseError } from "./time-range";
+import { runInsightsQuery, QueryRow } from "./insights";
+
+type OutputFormat = "ndjson" | "json" | "tsv";
+
+interface CliOptions {
+  logGroup: string[];
+  time: string;
+  query?: string;
+  queryFile?: string;
+  limit?: number;
+  region?: string;
+  profile?: string;
+  output: OutputFormat;
+  quiet: boolean;
+}
+
+const DEFAULT_QUERY = "fields @timestamp, @message | sort @timestamp desc";
+
+function parsePositiveInt(raw: string): number {
+  const n = parseInt(raw, 10);
+  if (!Number.isFinite(n) || n <= 0) {
+    throw new InvalidArgumentError("expected a positive integer");
+  }
+  return n;
+}
+
+function parseOutput(raw: string): OutputFormat {
+  if (raw !== "ndjson" && raw !== "json" && raw !== "tsv") {
+    throw new InvalidArgumentError(`unknown output format: ${raw}`);
+  }
+  return raw;
+}
+
+function buildProgram(): Command {
+  const program = new Command();
+  program
+    .name("cloudwatch-insights")
+    .description(
+      "Download logs from AWS CloudWatch Logs Insights.\n\n" +
+        "Time range examples:\n" +
+        '  5h                                last 5 hours\n' +
+        '  30m                               last 30 minutes\n' +
+        '  500ms                             last 500 milliseconds\n' +
+        '  13.00-13.01                       time range today\n' +
+        '  09:15:00.000-09:15:00.500         millisecond precision today\n' +
+        '  yesterday 17-18                   time range on a named day\n' +
+        '  2026-04-22T13:00:00Z/2026-04-22T14:00:00Z   explicit ISO range\n' +
+        '  "last Monday 9am to 5pm"          natural language (chrono-node)\n',
+    )
+    .requiredOption(
+      "-g, --log-group <name...>",
+      "log group name (repeat or comma-separate to query multiple)",
+      (value: string, previous: string[] = []) => previous.concat(value.split(",").map((s) => s.trim()).filter(Boolean)),
+      [] as string[],
+    )
+    .requiredOption("-t, --time <range>", "time range (see examples above)")
+    .option("-q, --query <string>", "CloudWatch Insights query string")
+    .option("-f, --query-file <path>", "read query from file (use '-' for stdin)")
+    .option<number>("-l, --limit <n>", "maximum number of rows to return", parsePositiveInt)
+    .option("-r, --region <region>", "AWS region (overrides AWS_REGION)")
+    .option("--profile <name>", "AWS profile (sets AWS_PROFILE)")
+    .option<OutputFormat>(
+      "-o, --output <format>",
+      "output format: ndjson, json, tsv",
+      parseOutput,
+      "ndjson" as OutputFormat,
+    )
+    .option("--quiet", "suppress progress output on stderr", false);
+  return program;
+}
+
+function resolveQuery(options: CliOptions): string {
+  if (options.query && options.queryFile) {
+    throw new Error("--query and --query-file are mutually exclusive");
+  }
+  if (options.query) return options.query;
+  if (options.queryFile) {
+    const source = options.queryFile === "-" ? 0 : options.queryFile;
+    return readFileSync(source, "utf8");
+  }
+  return DEFAULT_QUERY;
+}
+
+function renderRows(rows: QueryRow[], format: OutputFormat): void {
+  switch (format) {
+    case "ndjson":
+      for (const row of rows) {
+        process.stdout.write(JSON.stringify(row) + "\n");
+      }
+      break;
+    case "json":
+      process.stdout.write(JSON.stringify(rows, null, 2) + "\n");
+      break;
+    case "tsv": {
+      if (rows.length === 0) return;
+      const columns = collectColumns(rows);
+      process.stdout.write(columns.join("\t") + "\n");
+      for (const row of rows) {
+        const line = columns.map((c) => escapeTsv(row[c] ?? "")).join("\t");
+        process.stdout.write(line + "\n");
+      }
+      break;
+    }
+  }
+}
+
+function collectColumns(rows: QueryRow[]): string[] {
+  const seen = new Set<string>();
+  const order: string[] = [];
+  for (const row of rows) {
+    for (const key of Object.keys(row)) {
+      if (key === "@ptr") continue;
+      if (!seen.has(key)) {
+        seen.add(key);
+        order.push(key);
+      }
+    }
+  }
+  return order;
+}
+
+function escapeTsv(value: string): string {
+  return value.replace(/\t/g, " ").replace(/\r?\n/g, " ");
+}
+
+async function main(): Promise<void> {
+  const program = buildProgram();
+  program.parse(process.argv);
+  const options = program.opts<CliOptions>();
+
+  const query = resolveQuery(options);
+
+  let range;
+  try {
+    range = parseTimeRange(options.time);
+  } catch (err) {
+    if (err instanceof TimeRangeParseError) {
+      process.stderr.write(`error: ${err.message}\n`);
+      process.exit(2);
+    }
+    throw err;
+  }
+
+  if (options.profile) {
+    process.env.AWS_PROFILE = options.profile;
+  }
+
+  const client = new CloudWatchLogsClient({
+    region: options.region ?? process.env.AWS_REGION,
+  });
+
+  if (!options.quiet) {
+    process.stderr.write(
+      `Querying ${options.logGroup.length} log group(s) from ${range.startTime.toISOString()} ` +
+        `to ${range.endTime.toISOString()}\n`,
+    );
+  }
+
+  let lastStatus = "";
+  const result = await runInsightsQuery({
+    client,
+    logGroups: options.logGroup,
+    queryString: query,
+    startTime: range.startTime,
+    endTime: range.endTime,
+    limit: options.limit,
+    onStatus: (status) => {
+      if (options.quiet || status === lastStatus) return;
+      lastStatus = String(status);
+      process.stderr.write(`  status: ${status}\n`);
+    },
+  });
+
+  renderRows(result.rows, options.output);
+
+  if (!options.quiet && result.statistics) {
+    const { recordsMatched, recordsScanned, bytesScanned } = result.statistics;
+    process.stderr.write(
+      `Done. ${result.rows.length} rows returned ` +
+        `(matched=${recordsMatched ?? "?"} scanned=${recordsScanned ?? "?"} bytes=${bytesScanned ?? "?"}).\n`,
+    );
+  }
+}
+
+main().catch((err: unknown) => {
+  const message = err instanceof Error ? err.message : String(err);
+  process.stderr.write(`error: ${message}\n`);
+  process.exit(1);
+});

--- a/cloudwatch-insights/src/insights.ts
+++ b/cloudwatch-insights/src/insights.ts
@@ -1,0 +1,113 @@
+import {
+  CloudWatchLogsClient,
+  GetQueryResultsCommand,
+  QueryStatus,
+  ResultField,
+  StartQueryCommand,
+} from "@aws-sdk/client-cloudwatch-logs";
+
+export interface RunQueryOptions {
+  client: CloudWatchLogsClient;
+  logGroups: string[];
+  queryString: string;
+  startTime: Date;
+  endTime: Date;
+  limit?: number;
+  /** Polling interval in ms. Defaults to 1000. */
+  pollIntervalMs?: number;
+  /** Called after each poll so callers can surface progress. */
+  onStatus?: (status: QueryStatus | string) => void;
+}
+
+export interface QueryRow {
+  [field: string]: string;
+}
+
+export interface QueryResult {
+  rows: QueryRow[];
+  statistics?: {
+    recordsMatched?: number;
+    recordsScanned?: number;
+    bytesScanned?: number;
+  };
+  status: QueryStatus | string;
+}
+
+const TERMINAL_STATUSES: ReadonlySet<string> = new Set([
+  QueryStatus.Complete,
+  QueryStatus.Failed,
+  QueryStatus.Cancelled,
+  QueryStatus.Timeout,
+  "Unknown",
+]);
+
+export async function runInsightsQuery(options: RunQueryOptions): Promise<QueryResult> {
+  const {
+    client,
+    logGroups,
+    queryString,
+    startTime,
+    endTime,
+    limit,
+    pollIntervalMs = 1_000,
+    onStatus,
+  } = options;
+
+  if (logGroups.length === 0) {
+    throw new Error("at least one log group is required");
+  }
+
+  const start = await client.send(
+    new StartQueryCommand({
+      logGroupNames: logGroups,
+      startTime: Math.floor(startTime.getTime() / 1000),
+      endTime: Math.floor(endTime.getTime() / 1000),
+      queryString,
+      limit,
+    }),
+  );
+
+  const queryId = start.queryId;
+  if (!queryId) {
+    throw new Error("StartQuery did not return a queryId");
+  }
+
+  while (true) {
+    const response = await client.send(new GetQueryResultsCommand({ queryId }));
+    const status = response.status ?? "Unknown";
+    onStatus?.(status);
+
+    if (TERMINAL_STATUSES.has(status)) {
+      if (status !== QueryStatus.Complete) {
+        throw new Error(`query ended with status: ${status}`);
+      }
+      return {
+        status,
+        rows: (response.results ?? []).map(resultFieldsToRow),
+        statistics: response.statistics
+          ? {
+              recordsMatched: response.statistics.recordsMatched,
+              recordsScanned: response.statistics.recordsScanned,
+              bytesScanned: response.statistics.bytesScanned,
+            }
+          : undefined,
+      };
+    }
+
+    await sleep(pollIntervalMs);
+  }
+}
+
+function resultFieldsToRow(fields: ResultField[]): QueryRow {
+  const row: QueryRow = {};
+  for (const field of fields) {
+    if (field.field === undefined) continue;
+    // "@ptr" is CloudWatch's internal pointer; keep it so the user can drill down if needed.
+    row[field.field] = field.value ?? "";
+  }
+  return row;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/cloudwatch-insights/src/query-file.ts
+++ b/cloudwatch-insights/src/query-file.ts
@@ -1,0 +1,162 @@
+/**
+ * Per-repo ".insights" query files and their associated run outputs.
+ *
+ * Directory layout under SKAGEDAL_TOOLS_HOME/cloudwatch-insights/:
+ *
+ *   latest-run.jsonl                     symlink → most recently written results file
+ *   queries/
+ *     <slot>/
+ *       current.insights                 YAML front-matter + query body
+ *       results/
+ *         run-<timestamp>.jsonl          one row per line
+ *
+ * <slot> is the git repo's directory name, or "_default" when run outside
+ * a git repository.
+ */
+
+import { readFileSync, existsSync, mkdirSync, writeFileSync, lstatSync, unlinkSync, symlinkSync } from "fs";
+import { basename, dirname, join } from "path";
+import { parse as parseYaml } from "yaml";
+
+import { configPath, defaultQueryForApp, findGitRoot } from "./config.js";
+
+export const FALLBACK_QUERY = "fields @timestamp, @message | sort @timestamp desc";
+
+export interface FrontMatter {
+  time?: string;
+  environment?: string;
+  logGroup?: string | string[];
+  limit?: number;
+}
+
+export interface QueryFile {
+  frontMatter: FrontMatter;
+  body: string;
+}
+
+/** The skagedal-tools directory used for this tool (same base as configPath). */
+export function toolBaseDir(): string {
+  return dirname(configPath());
+}
+
+/** Slot name used for the queries subtree — repo basename or "_default". */
+export function currentSlot(cwd: string = process.cwd()): string {
+  const root = findGitRoot(cwd);
+  return root ? basename(root) : "_default";
+}
+
+export function currentInsightsPath(cwd: string = process.cwd()): string {
+  return join(toolBaseDir(), "queries", currentSlot(cwd), "current.insights");
+}
+
+export function resultsDir(cwd: string = process.cwd()): string {
+  return join(toolBaseDir(), "queries", currentSlot(cwd), "results");
+}
+
+export function latestRunPath(): string {
+  return join(toolBaseDir(), "latest-run.jsonl");
+}
+
+/**
+ * Ensure a current.insights file exists for the current slot, seeding it
+ * with a template that uses `app` for the default filter when provided.
+ * Returns whether a new file was written.
+ */
+export function ensureCurrentInsights(path: string, app?: string): boolean {
+  if (existsSync(path)) return false;
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, seedContent(app), { encoding: "utf8", flag: "wx" });
+  return true;
+}
+
+export function loadQueryFile(path: string): QueryFile {
+  const raw = readFileSync(path, "utf8");
+  return parseQueryFile(raw);
+}
+
+/**
+ * Parse a .insights file: optional YAML front-matter fenced by "---"
+ * lines, followed by the query body. If there is no front-matter, the
+ * entire file is treated as the body.
+ */
+export function parseQueryFile(contents: string): QueryFile {
+  const stripped = contents.replace(/^﻿/, "");
+  const lines = stripped.split(/\r?\n/);
+  if (lines.length === 0 || lines[0].trim() !== "---") {
+    return { frontMatter: {}, body: stripped.trim() };
+  }
+  let endIdx = -1;
+  for (let i = 1; i < lines.length; i++) {
+    if (lines[i].trim() === "---") {
+      endIdx = i;
+      break;
+    }
+  }
+  if (endIdx === -1) {
+    return { frontMatter: {}, body: stripped.trim() };
+  }
+  const yamlText = lines.slice(1, endIdx).join("\n");
+  const body = lines.slice(endIdx + 1).join("\n").trim();
+  const parsed = parseYaml(yamlText);
+  const frontMatter =
+    parsed && typeof parsed === "object" && !Array.isArray(parsed)
+      ? (parsed as FrontMatter)
+      : {};
+  return { frontMatter, body };
+}
+
+/** Build a filesystem-safe ISO-ish timestamp (no colons): 2026-04-23T14-30-45Z. */
+export function runTimestamp(now: Date = new Date()): string {
+  const iso = now.toISOString(); // 2026-04-23T14:30:45.123Z
+  return iso.replace(/\.\d+Z$/, "Z").replace(/:/g, "-");
+}
+
+export function runResultPath(cwd: string = process.cwd(), now: Date = new Date()): string {
+  return join(resultsDir(cwd), `run-${runTimestamp(now)}.jsonl`);
+}
+
+export interface WriteResultsOptions {
+  path: string;
+  rows: Array<Record<string, string>>;
+}
+
+/** Write rows as JSONL, creating the parent directory as needed. */
+export function writeResults({ path, rows }: WriteResultsOptions): void {
+  mkdirSync(dirname(path), { recursive: true });
+  const contents = rows.map((r) => JSON.stringify(r)).join("\n") + (rows.length ? "\n" : "");
+  writeFileSync(path, contents, "utf8");
+}
+
+/**
+ * Point latest-run.jsonl at `target`. Replaces any existing symlink or
+ * regular file at the path so the tool stays in a consistent state after
+ * every run.
+ */
+export function updateLatestSymlink(target: string): string {
+  const linkPath = latestRunPath();
+  mkdirSync(dirname(linkPath), { recursive: true });
+  try {
+    const stat = lstatSync(linkPath);
+    if (stat.isSymbolicLink() || stat.isFile()) {
+      unlinkSync(linkPath);
+    }
+  } catch {
+    // nothing to remove
+  }
+  symlinkSync(target, linkPath);
+  return linkPath;
+}
+
+function seedContent(app?: string): string {
+  const query = app ? defaultQueryForApp(app) : FALLBACK_QUERY;
+  return `---
+# Front-matter (YAML). Optional defaults for this query.
+# Examples:
+#   time: 5h
+#   environment: systest
+#   logGroup: /my/group
+#   limit: 100
+---
+${query}
+`;
+}

--- a/cloudwatch-insights/src/query-file.ts
+++ b/cloudwatch-insights/src/query-file.ts
@@ -18,15 +18,12 @@ import { readFileSync, existsSync, mkdirSync, writeFileSync, lstatSync, unlinkSy
 import { basename, dirname, join } from "path";
 import { parse as parseYaml } from "yaml";
 
-import { configPath, defaultQueryForApp, findGitRoot } from "./config.js";
-
-export const FALLBACK_QUERY = "fields @timestamp, @message | sort @timestamp desc";
+import { configPath, defaultQuery, findGitRoot } from "./config.js";
 
 export interface FrontMatter {
   time?: string;
   environment?: string;
   logGroup?: string | string[];
-  limit?: number;
 }
 
 export interface QueryFile {
@@ -67,6 +64,16 @@ export function ensureCurrentInsights(path: string, app?: string): boolean {
   mkdirSync(dirname(path), { recursive: true });
   writeFileSync(path, seedContent(app), { encoding: "utf8", flag: "wx" });
   return true;
+}
+
+/**
+ * Unconditionally reset current.insights to the default template (used
+ * by `query --clear`). Returns the path that was written.
+ */
+export function resetCurrentInsights(path: string, app?: string): string {
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, seedContent(app), "utf8");
+  return path;
 }
 
 export function loadQueryFile(path: string): QueryFile {
@@ -148,15 +155,13 @@ export function updateLatestSymlink(target: string): string {
 }
 
 function seedContent(app?: string): string {
-  const query = app ? defaultQueryForApp(app) : FALLBACK_QUERY;
   return `---
 # Front-matter (YAML). Optional defaults for this query.
 # Examples:
 #   time: 5h
 #   environment: systest
 #   logGroup: /my/group
-#   limit: 100
 ---
-${query}
+${defaultQuery(app)}
 `;
 }

--- a/cloudwatch-insights/src/time-range.ts
+++ b/cloudwatch-insights/src/time-range.ts
@@ -1,0 +1,223 @@
+/**
+ * Flexible time-range parser.
+ *
+ * Primary ("shorthand") forms, evaluated in order:
+ *
+ *   1. Relative duration from now: "5h", "30m", "45s", "500ms", "2d", "1w".
+ *
+ *   2. Day keyword + time range on that day: "yesterday 17-18",
+ *      "today 13.00-13.01.30", "yesterday 09:15:00.000-09:15:00.500".
+ *
+ *   3. Time-only range on today: "13.00-13.01", "13:00-13:01",
+ *      "09.15.30-09.15.31", "09.15.30.000-09.15.30.500".
+ *
+ *   4. Explicit range with an explicit separator between the endpoints.
+ *      Supported separators: "/", "..", and " to ". Either side may be a
+ *      bare time (interpreted as today), a full date, or a full ISO
+ *      datetime. Example: "2026-04-22T13:00:00Z/2026-04-22T14:00:00Z".
+ *
+ * As a final fallback we hand the whole expression to chrono-node, which
+ * supports a wide range of natural-language dates and ranges (e.g.
+ * "last Monday from 9am to 5pm", "Apr 22 13:00 to 14:00"). Chrono results
+ * without an explicit end instant are rejected — we need a real range.
+ */
+
+import * as chrono from "chrono-node";
+
+export interface TimeRange {
+  /** Inclusive start of the range. */
+  startTime: Date;
+  /** Exclusive end of the range. */
+  endTime: Date;
+}
+
+const MS_PER_UNIT: Record<string, number> = {
+  ms: 1,
+  s: 1_000,
+  m: 60_000,
+  h: 3_600_000,
+  d: 86_400_000,
+  w: 7 * 86_400_000,
+};
+
+const DURATION_RE = /^(\d+(?:\.\d+)?)(ms|s|m|h|d|w)$/;
+
+// Time with "." or ":" as separator. Captures H, M?, S?, MS?.
+const TIME_RE = /^(\d{1,2})(?:[.:](\d{1,2})(?:[.:](\d{1,2})(?:\.(\d{1,3}))?)?)?$/;
+
+const DAY_KEYWORDS = new Set(["today", "yesterday"]);
+
+export class TimeRangeParseError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "TimeRangeParseError";
+  }
+}
+
+/**
+ * Parse a time-range expression.
+ *
+ * @param input The user-supplied range string.
+ * @param now   Reference "now" (for testability). Defaults to the current time.
+ */
+export function parseTimeRange(input: string, now: Date = new Date()): TimeRange {
+  const trimmed = input.trim();
+  if (!trimmed) {
+    throw new TimeRangeParseError("empty time range");
+  }
+
+  const duration = tryParseDuration(trimmed, now);
+  if (duration) return duration;
+
+  const dayKeyword = tryParseDayKeywordRange(trimmed, now);
+  if (dayKeyword) return dayKeyword;
+
+  const timeOnly = tryParseTimeOnlyRange(trimmed, now);
+  if (timeOnly) return timeOnly;
+
+  const explicit = tryParseExplicitRange(trimmed, now);
+  if (explicit) return explicit;
+
+  const fromChrono = tryParseWithChrono(trimmed, now);
+  if (fromChrono) return fromChrono;
+
+  throw new TimeRangeParseError(`could not parse time range: ${JSON.stringify(input)}`);
+}
+
+function tryParseDuration(input: string, now: Date): TimeRange | null {
+  const match = DURATION_RE.exec(input);
+  if (!match) return null;
+  const amount = parseFloat(match[1]);
+  const unit = match[2];
+  const ms = amount * MS_PER_UNIT[unit];
+  return { startTime: new Date(now.getTime() - ms), endTime: now };
+}
+
+function tryParseDayKeywordRange(input: string, now: Date): TimeRange | null {
+  const spaceIdx = input.indexOf(" ");
+  if (spaceIdx < 0) {
+    // A bare day keyword means the full day.
+    const word = input.toLowerCase();
+    if (!DAY_KEYWORDS.has(word)) return null;
+    const base = resolveDayKeyword(word, now);
+    return {
+      startTime: base,
+      endTime: new Date(base.getTime() + MS_PER_UNIT.d),
+    };
+  }
+
+  const word = input.slice(0, spaceIdx).toLowerCase();
+  if (!DAY_KEYWORDS.has(word)) return null;
+  const rest = input.slice(spaceIdx + 1).trim();
+  const base = resolveDayKeyword(word, now);
+
+  const range = parseTimeRangeString(rest, base);
+  if (range) return range;
+
+  // Let chrono handle "yesterday at 5pm to 6pm" etc.
+  return null;
+}
+
+function tryParseTimeOnlyRange(input: string, now: Date): TimeRange | null {
+  const base = startOfDay(now);
+  return parseTimeRangeString(input, base);
+}
+
+/** Parse "TIME-TIME" where each TIME uses dots/colons (no dashes of its own). */
+function parseTimeRangeString(input: string, base: Date): TimeRange | null {
+  const dashIdx = input.indexOf("-");
+  if (dashIdx <= 0) return null;
+  const leftRaw = input.slice(0, dashIdx).trim();
+  const rightRaw = input.slice(dashIdx + 1).trim();
+  const left = parseTimeOfDay(leftRaw);
+  const right = parseTimeOfDay(rightRaw);
+  if (left === null || right === null) return null;
+  const startTime = new Date(base.getTime() + left);
+  let endTime = new Date(base.getTime() + right);
+  // Allow wrap past midnight (e.g. "23.30-00.30").
+  if (endTime.getTime() <= startTime.getTime()) {
+    endTime = new Date(endTime.getTime() + MS_PER_UNIT.d);
+  }
+  return { startTime, endTime };
+}
+
+/** Parse "HH", "HH:MM", "HH.MM.SS", "HH.MM.SS.mmm" etc. Returns ms-of-day or null. */
+function parseTimeOfDay(input: string): number | null {
+  const match = TIME_RE.exec(input);
+  if (!match) return null;
+  const h = parseInt(match[1], 10);
+  const m = match[2] ? parseInt(match[2], 10) : 0;
+  const s = match[3] ? parseInt(match[3], 10) : 0;
+  const ms = match[4] ? parseInt(match[4].padEnd(3, "0"), 10) : 0;
+  if (h > 23 || m > 59 || s > 59) return null;
+  return h * MS_PER_UNIT.h + m * MS_PER_UNIT.m + s * MS_PER_UNIT.s + ms;
+}
+
+function tryParseExplicitRange(input: string, now: Date): TimeRange | null {
+  const separators = [" to ", "..", "/"];
+  for (const sep of separators) {
+    const idx = input.indexOf(sep);
+    if (idx < 0) continue;
+    const left = input.slice(0, idx).trim();
+    const right = input.slice(idx + sep.length).trim();
+    return {
+      startTime: parseInstant(left, now),
+      endTime: parseInstant(right, now),
+    };
+  }
+  return null;
+}
+
+function tryParseWithChrono(input: string, now: Date): TimeRange | null {
+  const results = chrono.parse(input, now);
+  if (results.length === 0) return null;
+  const first = results[0];
+  if (!first.end) return null;
+  return { startTime: first.start.date(), endTime: first.end.date() };
+}
+
+/**
+ * Parse a single instant (used for each side of an explicit range).
+ * Accepts bare times, day keywords, ISO dates/datetimes, or anything
+ * chrono-node can understand.
+ */
+function parseInstant(input: string, now: Date): Date {
+  const timeOfDay = parseTimeOfDay(input);
+  if (timeOfDay !== null) {
+    return new Date(startOfDay(now).getTime() + timeOfDay);
+  }
+
+  const lower = input.toLowerCase();
+  if (DAY_KEYWORDS.has(lower)) {
+    return resolveDayKeyword(lower, now);
+  }
+
+  // "YYYY-MM-DD HH:MM[:SS[.mmm]]" → turn the space into "T" so Date parses it.
+  let normalized = input;
+  if (/^\d{4}-\d{2}-\d{2} /.test(normalized)) {
+    normalized = normalized.replace(" ", "T");
+  }
+
+  const direct = new Date(normalized);
+  if (!isNaN(direct.getTime())) {
+    return direct;
+  }
+
+  const chronoResult = chrono.parseDate(input, now);
+  if (chronoResult) return chronoResult;
+
+  throw new TimeRangeParseError(`could not parse instant: ${JSON.stringify(input)}`);
+}
+
+function startOfDay(d: Date): Date {
+  return new Date(d.getFullYear(), d.getMonth(), d.getDate());
+}
+
+function resolveDayKeyword(word: string, now: Date): Date {
+  const base = startOfDay(now);
+  if (word === "today") return base;
+  if (word === "yesterday") {
+    return new Date(base.getTime() - MS_PER_UNIT.d);
+  }
+  throw new TimeRangeParseError(`unknown day keyword: ${word}`);
+}

--- a/cloudwatch-insights/test/config.test.ts
+++ b/cloudwatch-insights/test/config.test.ts
@@ -1,0 +1,132 @@
+import { test } from "node:test";
+import { strict as assert } from "node:assert";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { spawnSync } from "child_process";
+
+import {
+  applyEnvironment,
+  ConfigError,
+  configPath,
+  defaultQueryForApp,
+  findGitRoot,
+  loadSettings,
+  parseSettings,
+  resolveRepoDefaults,
+} from "../src/config";
+
+test("parseSettings: extracts group and app from a named section", () => {
+  const settings = parseSettings(
+    [
+      "[installer-notification]",
+      'group = "/{env}/team-icc"',
+      'app = "installer-notification"',
+      "",
+      "[another-service]",
+      'group = "/prod/another"',
+    ].join("\n"),
+  );
+
+  assert.deepEqual(settings.sections["installer-notification"], {
+    group: "/{env}/team-icc",
+    app: "installer-notification",
+  });
+  assert.deepEqual(settings.sections["another-service"], {
+    group: "/prod/another",
+  });
+});
+
+test("parseSettings: ignores unknown keys and non-table values", () => {
+  const settings = parseSettings(
+    [
+      "unused = 42",
+      "[repo]",
+      'group = "/foo"',
+      "extra = 99",
+    ].join("\n"),
+  );
+  assert.deepEqual(settings.sections["repo"], { group: "/foo" });
+  assert.ok(!("unused" in settings.sections));
+});
+
+test("parseSettings: rejects malformed TOML with a ConfigError", () => {
+  assert.throws(() => parseSettings("[broken"), ConfigError);
+});
+
+test("applyEnvironment: substitutes {env} and passes through otherwise", () => {
+  assert.equal(applyEnvironment("/prod/team", undefined), "/prod/team");
+  assert.equal(applyEnvironment("/{env}/team", "systest"), "/systest/team");
+  assert.equal(applyEnvironment("/{env}/team/{env}", "uat"), "/uat/team/uat");
+});
+
+test("applyEnvironment: errors when template uses {env} but env is missing", () => {
+  assert.throws(() => applyEnvironment("/{env}/team", undefined), ConfigError);
+});
+
+test("defaultQueryForApp: builds a filter-by-app Insights query", () => {
+  assert.equal(
+    defaultQueryForApp("installer-notification"),
+    'fields @timestamp, @message, app | filter app = "installer-notification" | sort @timestamp desc',
+  );
+});
+
+test("defaultQueryForApp: escapes embedded quotes", () => {
+  assert.equal(
+    defaultQueryForApp('weird"name'),
+    'fields @timestamp, @message, app | filter app = "weird\\"name" | sort @timestamp desc',
+  );
+});
+
+test("configPath: honors CLOUDWATCH_INSIGHTS_CONFIG, XDG_CONFIG_HOME, HOME", () => {
+  assert.equal(
+    configPath({ CLOUDWATCH_INSIGHTS_CONFIG: "/tmp/c.toml" }),
+    "/tmp/c.toml",
+  );
+  assert.equal(
+    configPath({ XDG_CONFIG_HOME: "/xdg" }),
+    "/xdg/cloudwatch-insights/settings.toml",
+  );
+});
+
+test("findGitRoot + resolveRepoDefaults work against a real git repo", () => {
+  const tmpRoot = mkdtempSync(join(tmpdir(), "cwi-test-"));
+  try {
+    const repoRoot = join(tmpRoot, "installer-notification");
+    mkdirSync(repoRoot);
+    const gitInit = spawnSync("git", ["init", "-q", "-b", "main"], { cwd: repoRoot });
+    assert.equal(gitInit.status, 0, "git init failed");
+
+    // Sanity: detect root
+    assert.equal(findGitRoot(repoRoot), repoRoot);
+
+    // Load minimal settings and resolve
+    const settings = loadSettings(writeSettings(tmpRoot, [
+      "[installer-notification]",
+      'group = "/{env}/team-icc"',
+      'app = "installer-notification"',
+    ].join("\n")));
+
+    const { sectionName, defaults } = resolveRepoDefaults(settings, repoRoot);
+    assert.equal(sectionName, "installer-notification");
+    assert.equal(defaults.group, "/{env}/team-icc");
+    assert.equal(defaults.app, "installer-notification");
+  } finally {
+    rmSync(tmpRoot, { recursive: true, force: true });
+  }
+});
+
+test("findGitRoot returns null outside a git repo", () => {
+  const tmp = mkdtempSync(join(tmpdir(), "cwi-nogit-"));
+  try {
+    assert.equal(findGitRoot(tmp), null);
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+function writeSettings(dir: string, contents: string): string {
+  const path = join(dir, "settings.toml");
+  writeFileSync(path, contents, "utf8");
+  return path;
+}

--- a/cloudwatch-insights/test/config.test.ts
+++ b/cloudwatch-insights/test/config.test.ts
@@ -9,7 +9,7 @@ import {
   applyEnvironment,
   ConfigError,
   configPath,
-  defaultQueryForApp,
+  defaultQuery,
   ensureConfigFile,
   findGitRoot,
   loadSettings,
@@ -65,17 +65,28 @@ test("applyEnvironment: errors when template uses {env} but env is missing", () 
   assert.throws(() => applyEnvironment("/{env}/team", undefined), ConfigError);
 });
 
-test("defaultQueryForApp: builds a filter-by-app Insights query", () => {
+test("defaultQuery: substitutes {app} placeholder", () => {
   assert.equal(
-    defaultQueryForApp("installer-notification"),
-    'fields @timestamp, @message, app | filter app = "installer-notification" | sort @timestamp desc',
+    defaultQuery("my-service"),
+    [
+      "fields @timestamp, @message",
+      "| sort @timestamp desc",
+      "| filter app = my-service",
+      "| filter level in ['WARN', 'ERROR']",
+      "| limit 200",
+    ].join("\n"),
   );
 });
 
-test("defaultQueryForApp: escapes embedded quotes", () => {
+test("defaultQuery: omits the app filter line when no app is given", () => {
   assert.equal(
-    defaultQueryForApp('weird"name'),
-    'fields @timestamp, @message, app | filter app = "weird\\"name" | sort @timestamp desc',
+    defaultQuery(),
+    [
+      "fields @timestamp, @message",
+      "| sort @timestamp desc",
+      "| filter level in ['WARN', 'ERROR']",
+      "| limit 200",
+    ].join("\n"),
   );
 });
 

--- a/cloudwatch-insights/test/config.test.ts
+++ b/cloudwatch-insights/test/config.test.ts
@@ -14,7 +14,7 @@ import {
   loadSettings,
   parseSettings,
   resolveRepoDefaults,
-} from "../src/config";
+} from "../src/config.js";
 
 test("parseSettings: extracts group and app from a named section", () => {
   const settings = parseSettings(

--- a/cloudwatch-insights/test/config.test.ts
+++ b/cloudwatch-insights/test/config.test.ts
@@ -1,6 +1,6 @@
 import { test } from "node:test";
 import { strict as assert } from "node:assert";
-import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "fs";
+import { mkdtempSync, mkdirSync, readFileSync, writeFileSync, rmSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
 import { spawnSync } from "child_process";
@@ -10,6 +10,7 @@ import {
   ConfigError,
   configPath,
   defaultQueryForApp,
+  ensureConfigFile,
   findGitRoot,
   loadSettings,
   parseSettings,
@@ -130,3 +131,70 @@ function writeSettings(dir: string, contents: string): string {
   writeFileSync(path, contents, "utf8");
   return path;
 }
+
+test("ensureConfigFile: creates file + placeholder on first call, is idempotent on later calls", () => {
+  const tmpRoot = mkdtempSync(join(tmpdir(), "cwi-ensure-"));
+  try {
+    const repoRoot = join(tmpRoot, "my-service");
+    mkdirSync(repoRoot);
+    assert.equal(
+      spawnSync("git", ["init", "-q", "-b", "main"], { cwd: repoRoot }).status,
+      0,
+    );
+    const settingsPath = join(tmpRoot, "settings.toml");
+
+    const first = ensureConfigFile(settingsPath, repoRoot);
+    assert.equal(first.fileCreated, true);
+    assert.equal(first.addedSection, "my-service");
+
+    const contents1 = readFileSync(settingsPath, "utf8");
+    assert.match(contents1, /# \[my-service\]/);
+    assert.match(contents1, /# group = /);
+    assert.match(contents1, /# app   = "my-service"/);
+
+    const second = ensureConfigFile(settingsPath, repoRoot);
+    assert.equal(second.fileCreated, false);
+    assert.equal(second.addedSection, null, "placeholder must not be duplicated");
+    assert.equal(readFileSync(settingsPath, "utf8"), contents1);
+  } finally {
+    rmSync(tmpRoot, { recursive: true, force: true });
+  }
+});
+
+test("ensureConfigFile: does nothing special when run outside a git repo", () => {
+  const tmpRoot = mkdtempSync(join(tmpdir(), "cwi-ensure-nogit-"));
+  try {
+    const settingsPath = join(tmpRoot, "settings.toml");
+    const result = ensureConfigFile(settingsPath, tmpRoot);
+    assert.equal(result.fileCreated, true);
+    assert.equal(result.addedSection, null);
+    const contents = readFileSync(settingsPath, "utf8");
+    assert.doesNotMatch(contents, /^\[/m, "no non-example section should be appended");
+  } finally {
+    rmSync(tmpRoot, { recursive: true, force: true });
+  }
+});
+
+test("ensureConfigFile: skips appending when the repo already has a real section", () => {
+  const tmpRoot = mkdtempSync(join(tmpdir(), "cwi-ensure-existing-"));
+  try {
+    const repoRoot = join(tmpRoot, "my-service");
+    mkdirSync(repoRoot);
+    assert.equal(
+      spawnSync("git", ["init", "-q", "-b", "main"], { cwd: repoRoot }).status,
+      0,
+    );
+    const settingsPath = writeSettings(
+      tmpRoot,
+      '[my-service]\ngroup = "/prod/team"\n',
+    );
+
+    const before = readFileSync(settingsPath, "utf8");
+    const result = ensureConfigFile(settingsPath, repoRoot);
+    assert.equal(result.fileCreated, false);
+    assert.equal(result.addedSection, null);
+    assert.equal(readFileSync(settingsPath, "utf8"), before);
+  } finally {
+    rmSync(tmpRoot, { recursive: true, force: true });
+  }
+});

--- a/cloudwatch-insights/test/config.test.ts
+++ b/cloudwatch-insights/test/config.test.ts
@@ -78,14 +78,14 @@ test("defaultQueryForApp: escapes embedded quotes", () => {
   );
 });
 
-test("configPath: honors CLOUDWATCH_INSIGHTS_CONFIG, XDG_CONFIG_HOME, HOME", () => {
+test("configPath: honors CLOUDWATCH_INSIGHTS_CONFIG and SKAGEDAL_TOOLS_HOME", () => {
   assert.equal(
     configPath({ CLOUDWATCH_INSIGHTS_CONFIG: "/tmp/c.toml" }),
     "/tmp/c.toml",
   );
   assert.equal(
-    configPath({ XDG_CONFIG_HOME: "/xdg" }),
-    "/xdg/cloudwatch-insights/settings.toml",
+    configPath({ SKAGEDAL_TOOLS_HOME: "/custom" }),
+    "/custom/cloudwatch-insights/settings.toml",
   );
 });
 

--- a/cloudwatch-insights/test/query-file.test.ts
+++ b/cloudwatch-insights/test/query-file.test.ts
@@ -1,0 +1,126 @@
+import { test } from "node:test";
+import { strict as assert } from "node:assert";
+import { mkdtempSync, mkdirSync, readFileSync, writeFileSync, readlinkSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+
+import {
+  ensureCurrentInsights,
+  loadQueryFile,
+  parseQueryFile,
+  runTimestamp,
+  updateLatestSymlink,
+  writeResults,
+} from "../src/query-file.js";
+
+test("parseQueryFile: no front-matter — whole file is body", () => {
+  const { frontMatter, body } = parseQueryFile(
+    "fields @timestamp, @message | sort @timestamp desc",
+  );
+  assert.deepEqual(frontMatter, {});
+  assert.equal(body, "fields @timestamp, @message | sort @timestamp desc");
+});
+
+test("parseQueryFile: YAML front-matter with time and logGroup", () => {
+  const { frontMatter, body } = parseQueryFile(
+    [
+      "---",
+      "time: 5h",
+      "logGroup: /prod/team",
+      "limit: 100",
+      "---",
+      "fields @timestamp, @message",
+      "| sort @timestamp desc",
+      "",
+    ].join("\n"),
+  );
+  assert.deepEqual(frontMatter, {
+    time: "5h",
+    logGroup: "/prod/team",
+    limit: 100,
+  });
+  assert.equal(body, "fields @timestamp, @message\n| sort @timestamp desc");
+});
+
+test("parseQueryFile: front-matter logGroup can be an array", () => {
+  const { frontMatter } = parseQueryFile(
+    "---\nlogGroup:\n  - /a\n  - /b\n---\nfields @timestamp",
+  );
+  assert.deepEqual(frontMatter.logGroup, ["/a", "/b"]);
+});
+
+test("parseQueryFile: unterminated front-matter treated as body", () => {
+  const raw = "---\ntime: 5h\nfields @timestamp, @message";
+  const { frontMatter, body } = parseQueryFile(raw);
+  assert.deepEqual(frontMatter, {});
+  assert.equal(body, raw);
+});
+
+test("parseQueryFile: empty front-matter block is valid (no keys)", () => {
+  const { frontMatter, body } = parseQueryFile("---\n---\nfields @timestamp");
+  assert.deepEqual(frontMatter, {});
+  assert.equal(body, "fields @timestamp");
+});
+
+test("ensureCurrentInsights: seeds with app filter when app is provided", () => {
+  const tmp = mkdtempSync(join(tmpdir(), "cwi-qf-"));
+  try {
+    const path = join(tmp, "current.insights");
+    const created = ensureCurrentInsights(path, "my-service");
+    assert.equal(created, true);
+    const parsed = loadQueryFile(path);
+    assert.match(parsed.body, /filter app = "my-service"/);
+    assert.match(readFileSync(path, "utf8"), /^---\n/);
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test("ensureCurrentInsights: returns false when file already exists (idempotent)", () => {
+  const tmp = mkdtempSync(join(tmpdir(), "cwi-qf-exist-"));
+  try {
+    const path = join(tmp, "current.insights");
+    writeFileSync(path, "---\ntime: 1h\n---\nfields @timestamp\n", "utf8");
+    const before = readFileSync(path, "utf8");
+    const created = ensureCurrentInsights(path, "other-app");
+    assert.equal(created, false);
+    assert.equal(readFileSync(path, "utf8"), before);
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test("runTimestamp: produces a filesystem-safe ISO-ish string", () => {
+  const ts = runTimestamp(new Date("2026-04-23T14:30:45.123Z"));
+  assert.equal(ts, "2026-04-23T14-30-45Z");
+});
+
+test("writeResults + updateLatestSymlink: writes JSONL and points the symlink", () => {
+  const tmp = mkdtempSync(join(tmpdir(), "cwi-qf-results-"));
+  try {
+    process.env.SKAGEDAL_TOOLS_HOME = tmp;
+
+    const resultPath = join(tmp, "cloudwatch-insights", "queries", "repo", "results", "run-x.jsonl");
+    mkdirSync(join(tmp, "cloudwatch-insights"), { recursive: true });
+    writeResults({
+      path: resultPath,
+      rows: [{ "@timestamp": "2026", "@message": "hello" }],
+    });
+    assert.equal(
+      readFileSync(resultPath, "utf8"),
+      '{"@timestamp":"2026","@message":"hello"}\n',
+    );
+
+    const link = updateLatestSymlink(resultPath);
+    assert.equal(readlinkSync(link), resultPath);
+
+    // Second run should replace the symlink, not fail.
+    const other = join(tmp, "cloudwatch-insights", "queries", "repo", "results", "run-y.jsonl");
+    writeResults({ path: other, rows: [] });
+    updateLatestSymlink(other);
+    assert.equal(readlinkSync(link), other);
+  } finally {
+    delete process.env.SKAGEDAL_TOOLS_HOME;
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});

--- a/cloudwatch-insights/test/query-file.test.ts
+++ b/cloudwatch-insights/test/query-file.test.ts
@@ -8,6 +8,7 @@ import {
   ensureCurrentInsights,
   loadQueryFile,
   parseQueryFile,
+  resetCurrentInsights,
   runTimestamp,
   updateLatestSymlink,
   writeResults,
@@ -27,7 +28,6 @@ test("parseQueryFile: YAML front-matter with time and logGroup", () => {
       "---",
       "time: 5h",
       "logGroup: /prod/team",
-      "limit: 100",
       "---",
       "fields @timestamp, @message",
       "| sort @timestamp desc",
@@ -37,7 +37,6 @@ test("parseQueryFile: YAML front-matter with time and logGroup", () => {
   assert.deepEqual(frontMatter, {
     time: "5h",
     logGroup: "/prod/team",
-    limit: 100,
   });
   assert.equal(body, "fields @timestamp, @message\n| sort @timestamp desc");
 });
@@ -62,15 +61,30 @@ test("parseQueryFile: empty front-matter block is valid (no keys)", () => {
   assert.equal(body, "fields @timestamp");
 });
 
-test("ensureCurrentInsights: seeds with app filter when app is provided", () => {
+test("ensureCurrentInsights: seeds with the new default template + app filter", () => {
   const tmp = mkdtempSync(join(tmpdir(), "cwi-qf-"));
   try {
     const path = join(tmp, "current.insights");
     const created = ensureCurrentInsights(path, "my-service");
     assert.equal(created, true);
     const parsed = loadQueryFile(path);
-    assert.match(parsed.body, /filter app = "my-service"/);
+    assert.match(parsed.body, /filter app = my-service/);
+    assert.match(parsed.body, /filter level in \['WARN', 'ERROR'\]/);
+    assert.match(parsed.body, /limit 200/);
     assert.match(readFileSync(path, "utf8"), /^---\n/);
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test("ensureCurrentInsights: omits app filter when no app is configured", () => {
+  const tmp = mkdtempSync(join(tmpdir(), "cwi-qf-noapp-"));
+  try {
+    const path = join(tmp, "current.insights");
+    ensureCurrentInsights(path);
+    const parsed = loadQueryFile(path);
+    assert.doesNotMatch(parsed.body, /filter app/);
+    assert.match(parsed.body, /filter level in \['WARN', 'ERROR'\]/);
   } finally {
     rmSync(tmp, { recursive: true, force: true });
   }
@@ -85,6 +99,20 @@ test("ensureCurrentInsights: returns false when file already exists (idempotent)
     const created = ensureCurrentInsights(path, "other-app");
     assert.equal(created, false);
     assert.equal(readFileSync(path, "utf8"), before);
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test("resetCurrentInsights: overwrites an existing file with the default template", () => {
+  const tmp = mkdtempSync(join(tmpdir(), "cwi-qf-reset-"));
+  try {
+    const path = join(tmp, "current.insights");
+    writeFileSync(path, "---\n---\nuser-modified query", "utf8");
+    resetCurrentInsights(path, "my-service");
+    const parsed = loadQueryFile(path);
+    assert.doesNotMatch(parsed.body, /user-modified/);
+    assert.match(parsed.body, /filter app = my-service/);
   } finally {
     rmSync(tmp, { recursive: true, force: true });
   }

--- a/cloudwatch-insights/test/time-range.test.ts
+++ b/cloudwatch-insights/test/time-range.test.ts
@@ -1,7 +1,7 @@
 import { test } from "node:test";
 import { strict as assert } from "node:assert";
 
-import { parseTimeRange, TimeRangeParseError } from "../src/time-range";
+import { parseTimeRange, TimeRangeParseError } from "../src/time-range.js";
 
 // Fixed "now" — 2026-04-22 at 15:30:00 local time.
 const NOW = new Date(2026, 3, 22, 15, 30, 0);

--- a/cloudwatch-insights/test/time-range.test.ts
+++ b/cloudwatch-insights/test/time-range.test.ts
@@ -1,0 +1,124 @@
+import { test } from "node:test";
+import { strict as assert } from "node:assert";
+
+import { parseTimeRange, TimeRangeParseError } from "../src/time-range";
+
+// Fixed "now" — 2026-04-22 at 15:30:00 local time.
+const NOW = new Date(2026, 3, 22, 15, 30, 0);
+
+function ms(ymd: [number, number, number], hms: [number, number, number, number] = [0, 0, 0, 0]): number {
+  const [y, mo, d] = ymd;
+  const [h, mi, s, milli] = hms;
+  return new Date(y, mo - 1, d, h, mi, s, milli).getTime();
+}
+
+test("relative duration: hours", () => {
+  const { startTime, endTime } = parseTimeRange("5h", NOW);
+  assert.equal(endTime.getTime(), NOW.getTime());
+  assert.equal(startTime.getTime(), NOW.getTime() - 5 * 3_600_000);
+});
+
+test("relative duration: minutes, seconds, ms, days, weeks", () => {
+  for (const [input, msDelta] of [
+    ["30m", 30 * 60_000],
+    ["45s", 45 * 1_000],
+    ["500ms", 500],
+    ["2d", 2 * 86_400_000],
+    ["1w", 7 * 86_400_000],
+  ] as const) {
+    const { startTime, endTime } = parseTimeRange(input, NOW);
+    assert.equal(endTime.getTime(), NOW.getTime(), `${input} end`);
+    assert.equal(startTime.getTime(), NOW.getTime() - msDelta, `${input} start`);
+  }
+});
+
+test("time-only range with dots (today)", () => {
+  const { startTime, endTime } = parseTimeRange("13.00-13.01", NOW);
+  assert.equal(startTime.getTime(), ms([2026, 4, 22], [13, 0, 0, 0]));
+  assert.equal(endTime.getTime(), ms([2026, 4, 22], [13, 1, 0, 0]));
+});
+
+test("time-only range with colons", () => {
+  const { startTime, endTime } = parseTimeRange("09:00-10:00", NOW);
+  assert.equal(startTime.getTime(), ms([2026, 4, 22], [9, 0, 0, 0]));
+  assert.equal(endTime.getTime(), ms([2026, 4, 22], [10, 0, 0, 0]));
+});
+
+test("time-only range with seconds", () => {
+  const { startTime, endTime } = parseTimeRange("13.00.30-13.01.15", NOW);
+  assert.equal(startTime.getTime(), ms([2026, 4, 22], [13, 0, 30, 0]));
+  assert.equal(endTime.getTime(), ms([2026, 4, 22], [13, 1, 15, 0]));
+});
+
+test("time-only range with milliseconds", () => {
+  const { startTime, endTime } = parseTimeRange("09:15:00.000-09:15:00.500", NOW);
+  assert.equal(startTime.getTime(), ms([2026, 4, 22], [9, 15, 0, 0]));
+  assert.equal(endTime.getTime(), ms([2026, 4, 22], [9, 15, 0, 500]));
+});
+
+test("time-only range wraps past midnight", () => {
+  const { startTime, endTime } = parseTimeRange("23.30-00.30", NOW);
+  assert.equal(startTime.getTime(), ms([2026, 4, 22], [23, 30, 0, 0]));
+  assert.equal(endTime.getTime(), ms([2026, 4, 23], [0, 30, 0, 0]));
+});
+
+test("day keyword + time range: yesterday", () => {
+  const { startTime, endTime } = parseTimeRange("yesterday 17-18", NOW);
+  assert.equal(startTime.getTime(), ms([2026, 4, 21], [17, 0, 0, 0]));
+  assert.equal(endTime.getTime(), ms([2026, 4, 21], [18, 0, 0, 0]));
+});
+
+test("day keyword + time range: today with seconds", () => {
+  const { startTime, endTime } = parseTimeRange("today 13.00-13.01.30", NOW);
+  assert.equal(startTime.getTime(), ms([2026, 4, 22], [13, 0, 0, 0]));
+  assert.equal(endTime.getTime(), ms([2026, 4, 22], [13, 1, 30, 0]));
+});
+
+test("bare day keyword means the whole day", () => {
+  const { startTime, endTime } = parseTimeRange("yesterday", NOW);
+  assert.equal(startTime.getTime(), ms([2026, 4, 21]));
+  assert.equal(endTime.getTime(), ms([2026, 4, 22]));
+});
+
+test("explicit ISO range using '/'", () => {
+  const { startTime, endTime } = parseTimeRange(
+    "2026-04-22T13:00:00Z/2026-04-22T14:00:00Z",
+    NOW,
+  );
+  assert.equal(startTime.toISOString(), "2026-04-22T13:00:00.000Z");
+  assert.equal(endTime.toISOString(), "2026-04-22T14:00:00.000Z");
+});
+
+test("explicit range using '..' with space-separated date and time", () => {
+  const { startTime, endTime } = parseTimeRange(
+    "2026-04-22 13:00..2026-04-22 14:00",
+    NOW,
+  );
+  assert.equal(startTime.getTime(), ms([2026, 4, 22], [13, 0, 0, 0]));
+  assert.equal(endTime.getTime(), ms([2026, 4, 22], [14, 0, 0, 0]));
+});
+
+test("explicit range using ' to ' with bare times", () => {
+  const { startTime, endTime } = parseTimeRange("13.00 to 14.00", NOW);
+  assert.equal(startTime.getTime(), ms([2026, 4, 22], [13, 0, 0, 0]));
+  assert.equal(endTime.getTime(), ms([2026, 4, 22], [14, 0, 0, 0]));
+});
+
+test("natural-language fallback (chrono-node)", () => {
+  // "from X to Y" is the idiomatic form chrono understands.
+  const { startTime, endTime } = parseTimeRange(
+    "from 2026-04-22 13:00 to 2026-04-22 14:00",
+    NOW,
+  );
+  assert.ok(startTime.getTime() < endTime.getTime());
+  assert.equal(endTime.getTime() - startTime.getTime(), 3_600_000);
+});
+
+test("empty input is rejected", () => {
+  assert.throws(() => parseTimeRange("", NOW), TimeRangeParseError);
+  assert.throws(() => parseTimeRange("   ", NOW), TimeRangeParseError);
+});
+
+test("garbage input is rejected", () => {
+  assert.throws(() => parseTimeRange("not a time", NOW), TimeRangeParseError);
+});

--- a/cloudwatch-insights/tsconfig.json
+++ b/cloudwatch-insights/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "compilerOptions": {
     "target": "ES2022",
-    "module": "commonjs",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
     "lib": ["ES2022"],
     "outDir": "./dist",
     "rootDir": "./src",

--- a/cloudwatch-insights/tsconfig.json
+++ b/cloudwatch-insights/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "commonjs",
+    "lib": ["ES2022"],
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "declaration": false
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "test"]
+}

--- a/install.sh
+++ b/install.sh
@@ -3,23 +3,23 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-install_node() {
+install-node() {
     local dir="$1"
     echo "==> Installing $dir"
     (cd "$SCRIPT_DIR/$dir" && pnpm link --global)
 }
 
-install_rust() {
+install-rust() {
     local dir="$1"
     echo "==> Installing $dir"
     (cd "$SCRIPT_DIR/$dir" && cargo install --path .)
 }
 
-install_node linear-notifications
-install_node cloudwatch-insights
+install-node linear-notifications
+install-node cloudwatch-insights
 
-install_rust git-dirty-checker
-install_rust log-jsonify
-install_rust x-java-home
+install-rust git-dirty-checker
+install-rust log-jsonify
+install-rust x-java-home
 
 echo "==> Done"

--- a/install.sh
+++ b/install.sh
@@ -3,17 +3,20 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
+install_node() {
+    local dir="$1"
+    echo "==> Installing $dir"
+    (cd "$SCRIPT_DIR/$dir" && pnpm link --global)
+}
+
 install_rust() {
     local dir="$1"
     echo "==> Installing $dir"
     (cd "$SCRIPT_DIR/$dir" && cargo install --path .)
 }
 
-echo "==> Installing linear-notifications"
-(cd "$SCRIPT_DIR/linear-notifications" && pnpm link --global)
-
-echo "==> Installing cloudwatch-insights"
-(cd "$SCRIPT_DIR/cloudwatch-insights" && pnpm link --global)
+install_node linear-notifications
+install_node cloudwatch-insights
 
 install_rust git-dirty-checker
 install_rust log-jsonify

--- a/install.sh
+++ b/install.sh
@@ -12,6 +12,9 @@ install_rust() {
 echo "==> Installing linear-notifications"
 (cd "$SCRIPT_DIR/linear-notifications" && pnpm link --global)
 
+echo "==> Installing cloudwatch-insights"
+(cd "$SCRIPT_DIR/cloudwatch-insights" && pnpm link --global)
+
 install_rust git-dirty-checker
 install_rust log-jsonify
 install_rust x-java-home

--- a/install.sh
+++ b/install.sh
@@ -6,7 +6,12 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 install-node() {
     local dir="$1"
     echo "==> Installing $dir"
-    (cd "$SCRIPT_DIR/$dir" && pnpm link --global)
+    (
+        cd "$SCRIPT_DIR/$dir"
+        pnpm install
+        pnpm run build
+        pnpm link --global
+    )
 }
 
 install-rust() {


### PR DESCRIPTION
A TypeScript CLI for downloading logs from AWS CloudWatch Logs Insights,
featuring a flexible time-range syntax: relative durations (5h, 30m,
500ms), today time ranges (13.00-13.01), day keywords (yesterday 17-18),
explicit ISO ranges, and natural language via chrono-node.