### PR TITLE
Add dependency update script for all projects

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,6 +37,7 @@ All shell scripts in this repository must follow these guidelines:
 
 - Use `#!/usr/bin/env bash` as the shebang line instead of `#!/bin/bash`
   - This provides better portability across different systems where bash may be installed in different locations
+- Use dashes (not underscores) in bash function names (e.g. `update-cargo`, not `update_cargo`)
 
 ## Node.js Programs
 

--- a/install.sh
+++ b/install.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-install_rust() {
+install-rust() {
     local dir="$1"
     echo "==> Installing $dir"
     (cd "$SCRIPT_DIR/$dir" && cargo install --path .)
@@ -12,8 +12,8 @@ install_rust() {
 echo "==> Installing linear-notifications"
 (cd "$SCRIPT_DIR/linear-notifications" && pnpm link --global)
 
-install_rust git-dirty-checker
-install_rust log-jsonify
-install_rust x-java-home
+install-rust git-dirty-checker
+install-rust log-jsonify
+install-rust x-java-home
 
 echo "==> Done"

--- a/update
+++ b/update
@@ -3,31 +3,31 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-update_cargo() {
+update-cargo() {
     local dir="$1"
     echo "==> Updating $dir"
     (cd "$SCRIPT_DIR/$dir" && cargo update)
 }
 
-update_pnpm() {
+update-pnpm() {
     local dir="$1"
     echo "==> Updating $dir"
     (cd "$SCRIPT_DIR/$dir" && pnpm update)
 }
 
-update_maven() {
+update-maven() {
     local dir="$1"
     echo "==> Updating $dir"
     (cd "$SCRIPT_DIR/$dir" && mvn versions:use-latest-releases)
 }
 
-update_cargo git-dirty-checker
-update_cargo log-jsonify
-update_cargo x-java-home
+update-cargo git-dirty-checker
+update-cargo log-jsonify
+update-cargo x-java-home
 
-update_pnpm linear-notifications
-update_pnpm typescript-cli-arguments
+update-pnpm linear-notifications
+update-pnpm typescript-cli-arguments
 
-update_maven git-repos-latest-activity
+update-maven git-repos-latest-activity
 
 echo "==> Done"

--- a/update
+++ b/update
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+update_cargo() {
+    local dir="$1"
+    echo "==> Updating $dir"
+    (cd "$SCRIPT_DIR/$dir" && cargo update)
+}
+
+update_pnpm() {
+    local dir="$1"
+    echo "==> Updating $dir"
+    (cd "$SCRIPT_DIR/$dir" && pnpm update)
+}
+
+update_maven() {
+    local dir="$1"
+    echo "==> Updating $dir"
+    (cd "$SCRIPT_DIR/$dir" && mvn versions:use-latest-releases)
+}
+
+update_cargo git-dirty-checker
+update_cargo log-jsonify
+update_cargo x-java-home
+
+update_pnpm linear-notifications
+update_pnpm typescript-cli-arguments
+
+update_maven git-repos-latest-activity
+
+echo "==> Done"


### PR DESCRIPTION
## Summary
This PR introduces a new bash script to automate dependency updates across all projects in the repository, supporting multiple package managers.

## Key Changes
- Added `update` script that provides a centralized way to update dependencies for all projects
- Implemented support for three package managers:
  - **Cargo** (Rust): Updates `git-dirty-checker`, `log-jsonify`, and `x-java-home`
  - **pnpm** (Node.js): Updates `linear-notifications` and `typescript-cli-arguments`
  - **Maven** (Java): Updates `git-repos-latest-activity`
- Each package manager uses its standard update command with appropriate flags

## Implementation Details
- Script uses bash strict mode (`set -euo pipefail`) for safety and error handling
- Dynamically resolves script directory to support execution from any location
- Provides clear console output indicating which project is being updated
- Modular design with separate functions for each package manager type, making it easy to add new projects or managers in the future

https://claude.ai/code/session_014YwKQyfq58pz87hKChU2t8