### PR TITLE
Add details view and mark-as-read functionality

### DIFF
--- a/linear-notifications/README.md
+++ b/linear-notifications/README.md
@@ -23,7 +23,7 @@ This builds the TypeScript source and installs the `linear-notifications` comman
 linear-notifications
 ```
 
-If there are no unread notifications, the command exits immediately. Otherwise an inline interactive list appears:
+If there are no unread notifications, the command exits immediately. Otherwise a full-screen interactive list appears:
 
 ```
 Linear Notifications — 3 unread notifications

--- a/linear-notifications/README.md
+++ b/linear-notifications/README.md
@@ -23,17 +23,30 @@ This builds the TypeScript source and installs the `linear-notifications` comman
 linear-notifications
 ```
 
-If there are no unread notifications, the command exits immediately. Otherwise a full-screen interactive list appears:
+If there are no unread notifications, the command exits immediately. Otherwise a full-screen interactive UI appears, split between a list of notifications on top and a preview of the currently-selected notification below:
 
 ```
 Linear Notifications — 3 unread notifications
 ▶ ICC-820 Expose installation report submissions as flat tables    5m ago
   ICC-719 Update API rate limiting strategy                       2h ago
   ICC-701 Fix authentication bug in mobile app                    1d ago
-↑↓/jk: navigate  Enter: details  b: browser  m: mark read  r: reload  q: quit
+────────────────────────────────────────────────────────────────────────
+ICC-820 Expose installation report submissions as flat tables
+Alice commented
+
+Type:    IssueNotification
+Actor:   Alice
+Time:    5m ago (2025-11-01T12:34:56Z)
+Issue:   ICC-820 — Expose installation report submissions as flat tables
+URL:     https://linear.app/…
+
+Comment:
+> Could we also expose the per-row timestamps while we're here?
+────────────────────────────────────────────────────────────────────────
+↑↓/jk: navigate  Enter/o: open  b: browser  m: mark read  r: reload  q: quit
 ```
 
-Pressing `Enter` opens a full-screen details view for the selected notification. From either the list or the details view, `b` opens the notification URL in your browser without quitting, and `m` marks it as read and removes it from the list.
+Pressing `Enter` or `o` opens the full issue view for the selected notification, showing the issue's state, priority, assignee, description, and comments. From either view, `b` opens the notification URL in your browser without quitting, and `m` marks it as read and removes it from the list.
 
 ### Key bindings
 
@@ -43,19 +56,19 @@ Pressing `Enter` opens a full-screen details view for the selected notification.
 |-----|--------|
 | `↑` / `k` | Move selection up |
 | `↓` / `j` | Move selection down |
-| `Enter` | Show selected notification in full-screen details view |
+| `Enter` / `o` | Open the full issue view for the selected notification |
 | `b` | Open selected notification URL in the browser (stay in app) |
 | `m` | Mark selected notification as read |
 | `r` | Reload the notification list |
 | `q` / `Esc` | Quit |
 
-#### Details view
+#### Issue view
 
 | Key | Action |
 |-----|--------|
-| `b` | Open the notification URL in the browser |
+| `b` | Open the issue URL in the browser |
 | `m` | Mark the notification as read and return to the list |
-| `Enter` / `q` / `Esc` | Return to the list |
+| `u` / `Enter` / `q` / `Esc` | Return to the list |
 
 ## Development
 

--- a/linear-notifications/README.md
+++ b/linear-notifications/README.md
@@ -30,18 +30,32 @@ Linear Notifications — 3 unread notifications
 ▶ ICC-820 Expose installation report submissions as flat tables    5m ago
   ICC-719 Update API rate limiting strategy                       2h ago
   ICC-701 Fix authentication bug in mobile app                    1d ago
-↑↓/jk: navigate  Enter: open  r: reload  q/Esc: quit
+↑↓/jk: navigate  Enter: details  b: browser  m: mark read  r: reload  q: quit
 ```
 
+Pressing `Enter` opens a full-screen details view for the selected notification. From either the list or the details view, `b` opens the notification URL in your browser without quitting, and `m` marks it as read and removes it from the list.
+
 ### Key bindings
+
+#### List view
 
 | Key | Action |
 |-----|--------|
 | `↑` / `k` | Move selection up |
 | `↓` / `j` | Move selection down |
-| `Enter` | Open selected notification URL in the browser |
+| `Enter` | Show selected notification in full-screen details view |
+| `b` | Open selected notification URL in the browser (stay in app) |
+| `m` | Mark selected notification as read |
 | `r` | Reload the notification list |
 | `q` / `Esc` | Quit |
+
+#### Details view
+
+| Key | Action |
+|-----|--------|
+| `b` | Open the notification URL in the browser |
+| `m` | Mark the notification as read and return to the list |
+| `Enter` / `q` / `Esc` | Return to the list |
 
 ## Development
 

--- a/linear-notifications/package.json
+++ b/linear-notifications/package.json
@@ -14,7 +14,11 @@
   },
   "devDependencies": {
     "@types/node": "^22.0.0",
+    "@types/terminal-kit": "^2.5.7",
     "typescript": "^5.0.0"
   },
-  "packageManager": "pnpm@10.33.0"
+  "packageManager": "pnpm@10.33.0",
+  "dependencies": {
+    "terminal-kit": "^3.1.2"
+  }
 }

--- a/linear-notifications/pnpm-lock.yaml
+++ b/linear-notifications/pnpm-lock.yaml
@@ -7,18 +7,93 @@ settings:
 importers:
 
   .:
+    dependencies:
+      terminal-kit:
+        specifier: ^3.1.2
+        version: 3.1.2
     devDependencies:
       '@types/node':
         specifier: ^22.0.0
         version: 22.19.17
+      '@types/terminal-kit':
+        specifier: ^2.5.7
+        version: 2.5.7
       typescript:
         specifier: ^5.0.0
         version: 5.9.3
 
 packages:
 
+  '@cronvel/get-pixels@3.4.1':
+    resolution: {integrity: sha512-gB5C5nDIacLUdsMuW8YsM9SzK3vaFANe4J11CVXpovpy7bZUGrcJKmc6m/0gWG789pKr6XSZY2aEetjFvSRw5g==}
+
+  '@types/nextgen-events@1.1.4':
+    resolution: {integrity: sha512-YczHp+887i3MpHUOCOztk7y10SklNZ3aQlToKnu0LON0ZdFpgwq8POtnATAoFz8V1IxyR6d8pp8ZyYkUIy26Cw==}
+
   '@types/node@22.19.17':
     resolution: {integrity: sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==}
+
+  '@types/terminal-kit@2.5.7':
+    resolution: {integrity: sha512-IpbCBFSb3OqCEZBZlk368tGftqss88eNQaJdD9msEShRbksEiVahEqroONi60ppUt9/arLM6IDrHMx9jpzzCOw==}
+
+  chroma-js@2.6.0:
+    resolution: {integrity: sha512-BLHvCB9s8Z1EV4ethr6xnkl/P2YRFOGqfgvuMG/MyCbZPrTA+NeiByY6XvgF0zP4/2deU2CXnWyMa3zu1LqQ3A==}
+
+  cwise-compiler@1.1.3:
+    resolution: {integrity: sha512-WXlK/m+Di8DMMcCjcWr4i+XzcQra9eCdXIJrgh4TUgh0pIS/yJduLxS9JgefsHJ/YVLdgPtXm9r62W92MvanEQ==}
+
+  iota-array@1.0.0:
+    resolution: {integrity: sha512-pZ2xT+LOHckCatGQ3DcG/a+QuEqvoxqkiL7tvE8nn3uuu+f6i1TtpB5/FtWFbxUuVr5PZCx8KskuGatbJDXOWA==}
+
+  is-buffer@1.1.6:
+    resolution: {integrity: sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==}
+
+  jpeg-js@0.4.4:
+    resolution: {integrity: sha512-WZzeDOEtTOBK4Mdsar0IqEU5sMr3vSV2RqkAIzUEV2BHnUfKGyswWFPFwK5EeDo93K3FohSHbLAjj0s1Wzd+dg==}
+
+  lazyness@1.2.0:
+    resolution: {integrity: sha512-KenL6EFbwxBwRxG93t0gcUyi0Nw0Ub31FJKN1laA4UscdkL1K1AxUd0gYZdcLU3v+x+wcFi4uQKS5hL+fk500g==}
+    engines: {node: '>=6.0.0'}
+
+  ndarray-pack@1.2.1:
+    resolution: {integrity: sha512-51cECUJMT0rUZNQa09EoKsnFeDL4x2dHRT0VR5U2H5ZgEcm95ZDWcMA5JShroXjHOejmAD/fg8+H+OvUnVXz2g==}
+
+  ndarray@1.0.19:
+    resolution: {integrity: sha512-B4JHA4vdyZU30ELBw3g7/p9bZupyew5a7tX1Y/gGeF2hafrPaQZhgrGQfsvgfYbgdFZjYwuEcnaobeM/WMW+HQ==}
+
+  nextgen-events@1.5.3:
+    resolution: {integrity: sha512-P6qw6kenNXP+J9XlKJNi/MNHUQ+Lx5K8FEcSfX7/w8KJdZan5+BB5MKzuNgL2RTjHG1Svg8SehfseVEp8zAqwA==}
+    engines: {node: '>=6.0.0'}
+
+  node-bitmap@0.0.1:
+    resolution: {integrity: sha512-Jx5lPaaLdIaOsj2mVLWMWulXF6GQVdyLvNSxmiYCvZ8Ma2hfKX0POoR2kgKOqz+oFsRreq0yYZjQ2wjE9VNzCA==}
+    engines: {node: '>=v0.6.5'}
+
+  omggif@1.0.10:
+    resolution: {integrity: sha512-LMJTtvgc/nugXj0Vcrrs68Mn2D1r0zf630VNtqtpI1FEO7e+O9FP4gqs9AcnBaSEeoHIPm28u6qgPR0oyEpGSw==}
+
+  pngjs@6.0.0:
+    resolution: {integrity: sha512-TRzzuFRRmEoSW/p1KVAmiOgPco2Irlah+bGFCeNfJXxxYGwSw7YwAOAcd7X28K/m5bjBWKsC29KyoMfHbypayg==}
+    engines: {node: '>=12.13.0'}
+
+  setimmediate@1.0.5:
+    resolution: {integrity: sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==}
+
+  seventh@0.9.4:
+    resolution: {integrity: sha512-O85mosi4sOfxG+slvqy0j7zLuFD4ylUgEMt7Pvt9Q/wnwNwG/6MNnHKzV9JkAoPoPM26t/DLFn17p7o7u5kIBA==}
+    engines: {node: '>=16.13.0'}
+
+  string-kit@0.19.3:
+    resolution: {integrity: sha512-94p913R6+Ea6656A39bqJeHgt64HM9RSq36oc0F8N8Mz76g5+cLaqEwkouqguEDrJ4rhVQpS+tKz214FdtMoqA==}
+    engines: {node: '>=14.15.0'}
+
+  terminal-kit@3.1.2:
+    resolution: {integrity: sha512-ro2FyU4A+NwA74DLTYTnoCFYuFpgV1aM07IS6MPrJeajoI2hwF44EdUqjoTmKEl6srYDWtbVkc/b1C16iUnxFQ==}
+    engines: {node: '>=16.13.0'}
+
+  tree-kit@0.8.10:
+    resolution: {integrity: sha512-mwuV3lHL+utI9z7vxah/27wrMJprx925xhkw1N4KuGa1dqIi0DLHWfXJpHEyR+ZI0Ij80zN58ztiGp3KlH0wtw==}
+    engines: {node: '>=16.13.0'}
 
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
@@ -28,12 +103,85 @@ packages:
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
+  uniq@1.0.1:
+    resolution: {integrity: sha512-Gw+zz50YNKPDKXs+9d+aKAjVwpjNwqzvNpLigIruT4HA9lMZNdMqs9x07kKHB/L9WRzqp4+DlTU5s4wG2esdoA==}
+
 snapshots:
+
+  '@cronvel/get-pixels@3.4.1':
+    dependencies:
+      jpeg-js: 0.4.4
+      ndarray: 1.0.19
+      ndarray-pack: 1.2.1
+      node-bitmap: 0.0.1
+      omggif: 1.0.10
+      pngjs: 6.0.0
+
+  '@types/nextgen-events@1.1.4': {}
 
   '@types/node@22.19.17':
     dependencies:
       undici-types: 6.21.0
 
+  '@types/terminal-kit@2.5.7':
+    dependencies:
+      '@types/nextgen-events': 1.1.4
+
+  chroma-js@2.6.0: {}
+
+  cwise-compiler@1.1.3:
+    dependencies:
+      uniq: 1.0.1
+
+  iota-array@1.0.0: {}
+
+  is-buffer@1.1.6: {}
+
+  jpeg-js@0.4.4: {}
+
+  lazyness@1.2.0: {}
+
+  ndarray-pack@1.2.1:
+    dependencies:
+      cwise-compiler: 1.1.3
+      ndarray: 1.0.19
+
+  ndarray@1.0.19:
+    dependencies:
+      iota-array: 1.0.0
+      is-buffer: 1.1.6
+
+  nextgen-events@1.5.3: {}
+
+  node-bitmap@0.0.1: {}
+
+  omggif@1.0.10: {}
+
+  pngjs@6.0.0: {}
+
+  setimmediate@1.0.5: {}
+
+  seventh@0.9.4:
+    dependencies:
+      setimmediate: 1.0.5
+
+  string-kit@0.19.3: {}
+
+  terminal-kit@3.1.2:
+    dependencies:
+      '@cronvel/get-pixels': 3.4.1
+      chroma-js: 2.6.0
+      lazyness: 1.2.0
+      ndarray: 1.0.19
+      nextgen-events: 1.5.3
+      seventh: 0.9.4
+      string-kit: 0.19.3
+      tree-kit: 0.8.10
+
+  tree-kit@0.8.10: {}
+
   typescript@5.9.3: {}
 
   undici-types@6.21.0: {}
+
+  uniq@1.0.1: {}

--- a/linear-notifications/src/index.ts
+++ b/linear-notifications/src/index.ts
@@ -5,7 +5,7 @@ import termkit from "terminal-kit";
 
 const term = termkit.terminal;
 
-const GRAPHQL_QUERY = `query {
+const NOTIFICATIONS_QUERY = `query {
   notifications(first: 50) {
     nodes {
       id
@@ -49,6 +49,26 @@ interface Notification {
   comment?: { body: string } | null;
 }
 
+interface Issue {
+  identifier: string;
+  title: string;
+  description: string | null;
+  url: string;
+  createdAt: string;
+  state: { name: string } | null;
+  priorityLabel: string | null;
+  assignee: { name: string } | null;
+  creator: { name: string } | null;
+  labels: { nodes: Array<{ name: string }> };
+  comments: {
+    nodes: Array<{
+      body: string;
+      createdAt: string;
+      user: { name: string } | null;
+    }>;
+  };
+}
+
 function runLinearApi(query: string): any {
   const result = spawnSync("linear", ["api", query], { encoding: "utf8" });
 
@@ -69,9 +89,35 @@ function runLinearApi(query: string): any {
 }
 
 function fetchUnreadNotifications(): Notification[] {
-  const data = runLinearApi(GRAPHQL_QUERY);
+  const data = runLinearApi(NOTIFICATIONS_QUERY);
   const nodes: Notification[] = data?.data?.notifications?.nodes ?? [];
   return nodes.filter((n) => n.readAt === null);
+}
+
+function fetchIssue(identifier: string): Issue {
+  const query = `query { issue(id: "${identifier}") {
+    identifier
+    title
+    description
+    url
+    createdAt
+    state { name }
+    priorityLabel
+    assignee { name }
+    creator { name }
+    labels { nodes { name } }
+    comments(first: 50) {
+      nodes {
+        body
+        createdAt
+        user { name }
+      }
+    }
+  } }`;
+  const data = runLinearApi(query);
+  const issue = data?.data?.issue;
+  if (!issue) throw new Error(`Issue ${identifier} not found`);
+  return issue;
 }
 
 function markNotificationRead(id: string): void {
@@ -137,7 +183,50 @@ function countStatus(count: number): string {
   return `${count} unread notification${count !== 1 ? "s" : ""}`;
 }
 
-type Mode = "list" | "details";
+function safeW(): number {
+  return Math.max(0, term.width - 1);
+}
+
+type Mode = "list" | "issue";
+
+interface Row {
+  label: string;
+  value: string;
+}
+
+function metadataRows(n: Notification): Row[] {
+  const rows: Row[] = [
+    { label: "Type", value: n.type },
+    { label: "Actor", value: n.actor?.name ?? "—" },
+    { label: "Time", value: `${formatTime(n.createdAt)} (${n.createdAt})` },
+  ];
+  if (n.issue)
+    rows.push({
+      label: "Issue",
+      value: `${n.issue.identifier} — ${n.issue.title}`,
+    });
+  if (n.project) rows.push({ label: "Project", value: n.project.name });
+  if (n.pullRequest)
+    rows.push({
+      label: "PR",
+      value: `#${n.pullRequest.number} ${n.pullRequest.title}`,
+    });
+  rows.push({ label: "URL", value: n.url });
+  return rows;
+}
+
+function drawLabeledRows(startRow: number, maxRow: number, rows: Row[]): number {
+  const labelW = Math.max(...rows.map((r) => r.label.length)) + 2;
+  let row = startRow;
+  for (const { label, value } of rows) {
+    if (row > maxRow) break;
+    term.moveTo(1, row);
+    term.dim((label + ":").padEnd(labelW));
+    term(truncate(value, Math.max(0, safeW() - labelW)));
+    row++;
+  }
+  return row;
+}
 
 class App {
   notifications: Notification[];
@@ -145,7 +234,11 @@ class App {
   scrollOffset = 0;
   mode: Mode = "list";
   listStatus: string;
-  detailsStatus = "";
+  issueStatus = "";
+  issue: Issue | null = null;
+  issueError: string | null = null;
+  issueLoading = false;
+  issueCache = new Map<string, Issue>();
 
   constructor(notifications: Notification[]) {
     this.notifications = notifications;
@@ -158,139 +251,313 @@ class App {
 
   render(): void {
     if (this.mode === "list") this.renderList();
-    else this.renderDetails();
+    else this.renderIssue();
   }
 
   renderList(): void {
     term.clear();
+
     term.moveTo(1, 1);
     term.bold.cyan("Linear Notifications");
     term(" ");
     term.dim(`— ${this.listStatus}`);
 
+    const footerRow = term.height;
     const listTop = 3;
-    const listBottom = term.height - 1;
-    const maxItems = Math.max(1, listBottom - listTop + 1);
+    const maxListHeight = Math.max(
+      3,
+      Math.min(10, Math.floor((term.height - listTop - 2) * 0.4))
+    );
+    const listHeight = Math.min(this.notifications.length, maxListHeight);
+    const listBottom = listTop + listHeight - 1;
+    const separatorRow = listBottom + 1;
+    const previewTop = separatorRow + 1;
+    const previewBottom = footerRow - 1;
 
     if (this.selected < this.scrollOffset) {
       this.scrollOffset = this.selected;
-    } else if (this.selected >= this.scrollOffset + maxItems) {
-      this.scrollOffset = this.selected - maxItems + 1;
+    } else if (this.selected >= this.scrollOffset + listHeight) {
+      this.scrollOffset = this.selected - listHeight + 1;
     }
 
     const timeW = 8;
-    const visible = Math.min(maxItems, this.notifications.length - this.scrollOffset);
-    for (let i = 0; i < visible; i++) {
+    const rowW = safeW();
+    for (let i = 0; i < listHeight; i++) {
       const idx = i + this.scrollOffset;
+      if (idx >= this.notifications.length) break;
       const n = this.notifications[idx];
       const isSelected = idx === this.selected;
       const prefix = isSelected ? "▶ " : "  ";
-      const titleW = Math.max(0, term.width - timeW - prefix.length - 1);
+      const titleW = Math.max(0, rowW - timeW - prefix.length - 1);
       const title = truncate(n.title, titleW).padEnd(titleW);
       const time = formatTime(n.createdAt).padStart(timeW);
       const line = `${prefix}${title} ${time}`;
 
       term.moveTo(1, listTop + i);
-      const rowWidth = Math.max(0, term.width - 1);
       if (isSelected) {
-        term.inverse.bold(truncate(line, rowWidth).padEnd(rowWidth));
+        term.inverse.bold(truncate(line, rowW).padEnd(rowW));
       } else {
-        term(truncate(line, rowWidth));
+        term(truncate(line, rowW));
       }
     }
 
-    term.moveTo(1, term.height);
+    if (separatorRow <= footerRow - 1) {
+      term.moveTo(1, separatorRow);
+      term.dim("─".repeat(rowW));
+    }
+
+    if (previewTop <= previewBottom) {
+      this.renderPreview(previewTop, previewBottom);
+    }
+
+    term.moveTo(1, footerRow);
     term.dim(
       truncate(
-        "↑↓/jk: navigate  Enter: details  b: browser  m: mark read  r: reload  q: quit",
-        Math.max(0, term.width - 1)
+        "↑↓/jk: navigate  Enter/o: open  b: browser  m: mark read  r: reload  q: quit",
+        rowW
       )
     );
   }
 
-  renderDetails(): void {
+  renderPreview(top: number, bottom: number): void {
     const n = this.current();
     if (!n) return;
+    const w = safeW();
 
-    term.clear();
-    term.moveTo(1, 1);
-    term.bold.cyan(truncate(n.title, term.width));
+    let row = top;
 
-    let row = 2;
-    if (n.subtitle) {
+    term.moveTo(1, row);
+    term.bold(truncate(n.title, w));
+    row++;
+
+    if (n.subtitle && row <= bottom) {
       term.moveTo(1, row);
-      term.dim(truncate(n.subtitle, term.width));
-      row++;
-    }
-    row++; // blank line
-
-    const rows: Array<[string, string]> = [
-      ["Type", n.type],
-      ["Actor", n.actor?.name ?? "—"],
-      ["Time", `${formatTime(n.createdAt)} (${n.createdAt})`],
-    ];
-    if (n.issue)
-      rows.push(["Issue", `${n.issue.identifier} — ${n.issue.title}`]);
-    if (n.project) rows.push(["Project", n.project.name]);
-    if (n.pullRequest)
-      rows.push(["PR", `#${n.pullRequest.number} ${n.pullRequest.title}`]);
-    rows.push(["URL", n.url]);
-
-    const labelW = Math.max(...rows.map(([l]) => l.length)) + 2;
-    for (const [label, value] of rows) {
-      term.moveTo(1, row);
-      term.dim((label + ":").padEnd(labelW));
-      term(truncate(value, Math.max(0, term.width - labelW)));
+      term.dim(truncate(n.subtitle, w));
       row++;
     }
 
-    if (n.comment?.body) {
-      row++; // blank line
+    if (row <= bottom) row++; // blank line
+
+    row = drawLabeledRows(row, bottom, metadataRows(n));
+
+    if (n.comment?.body && row + 1 <= bottom) {
+      row++; // blank
       term.moveTo(1, row);
       term.bold("Comment");
       row++;
 
-      const footerRow = term.height;
-      const maxBodyRows = Math.max(0, footerRow - row - 1);
-      const bodyLines = wrapText(n.comment.body, term.width);
-      const shown = bodyLines.slice(0, maxBodyRows);
+      const bodyLines = wrapText(n.comment.body, w);
+      const available = bottom - row + 1;
+      const shown = bodyLines.slice(0, available);
       for (const line of shown) {
+        if (row > bottom) break;
         term.moveTo(1, row);
         term(line);
         row++;
       }
-      if (bodyLines.length > shown.length) {
-        term.moveTo(1, row);
+      if (bodyLines.length > shown.length && row - 1 <= bottom) {
+        term.moveTo(1, Math.min(row, bottom));
+        const leftover = bodyLines.length - shown.length;
         term.dim(
-          `… (${bodyLines.length - shown.length} more line${
-            bodyLines.length - shown.length !== 1 ? "s" : ""
-          })`
+          truncate(
+            `… (${leftover} more line${leftover !== 1 ? "s" : ""})`,
+            w
+          )
         );
       }
     }
-
-    term.moveTo(1, term.height);
-    const footerW = Math.max(0, term.width - 1);
-    const help = "b: browser  m: mark read  Enter/q: back";
-    const footer = this.detailsStatus
-      ? `${help}  ${this.detailsStatus}`
-      : help;
-    term.dim(truncate(footer, footerW));
   }
 
-  enterDetails(): void {
-    this.mode = "details";
-    this.detailsStatus = "";
+  renderIssue(): void {
+    term.clear();
+    const n = this.current();
+    if (!n) return;
+    const w = safeW();
+    const footerRow = term.height;
+    const bodyBottom = footerRow - 1;
+
+    const footerHelp = "b: browser  m: mark read  u/Enter/q: back";
+
+    const drawFooter = () => {
+      term.moveTo(1, footerRow);
+      const text = this.issueStatus
+        ? `${footerHelp}  ${this.issueStatus}`
+        : footerHelp;
+      term.dim(truncate(text, w));
+    };
+
+    if (this.issueLoading) {
+      term.moveTo(1, 1);
+      term.dim("Loading issue…");
+      drawFooter();
+      return;
+    }
+
+    if (this.issueError) {
+      term.moveTo(1, 1);
+      term.red(truncate(this.issueError, w));
+      drawFooter();
+      return;
+    }
+
+    if (this.issue) {
+      this.renderIssueBody(this.issue, bodyBottom, w);
+    } else {
+      // No associated issue — fall back to notification details
+      this.renderNotificationFallback(n, bodyBottom, w);
+    }
+
+    drawFooter();
+  }
+
+  renderIssueBody(issue: Issue, bottom: number, w: number): void {
+    let row = 1;
+
+    term.moveTo(1, row);
+    term.bold.cyan(truncate(`${issue.identifier}  ${issue.title}`, w));
+    row += 2;
+
+    const meta: Row[] = [];
+    if (issue.state) meta.push({ label: "State", value: issue.state.name });
+    if (issue.priorityLabel)
+      meta.push({ label: "Priority", value: issue.priorityLabel });
+    if (issue.assignee)
+      meta.push({ label: "Assignee", value: issue.assignee.name });
+    if (issue.creator)
+      meta.push({ label: "Creator", value: issue.creator.name });
+    meta.push({
+      label: "Created",
+      value: `${formatTime(issue.createdAt)} (${issue.createdAt})`,
+    });
+    const labelNames = issue.labels?.nodes?.map((l) => l.name) ?? [];
+    if (labelNames.length)
+      meta.push({ label: "Labels", value: labelNames.join(", ") });
+    meta.push({ label: "URL", value: issue.url });
+
+    row = drawLabeledRows(row, bottom, meta);
+
+    if (issue.description && row + 1 <= bottom) {
+      row++; // blank
+      term.moveTo(1, row);
+      term.bold("Description");
+      row++;
+      const lines = wrapText(issue.description, w);
+      for (const line of lines) {
+        if (row > bottom) return;
+        term.moveTo(1, row);
+        term(line);
+        row++;
+      }
+    }
+
+    const comments = issue.comments?.nodes ?? [];
+    if (comments.length && row + 1 <= bottom) {
+      row++;
+      term.moveTo(1, row);
+      term.bold(`Comments (${comments.length})`);
+      row++;
+      for (const c of comments) {
+        if (row > bottom) return;
+        term.moveTo(1, row);
+        term.dim(
+          truncate(
+            `— ${c.user?.name ?? "?"} · ${formatTime(c.createdAt)}`,
+            w
+          )
+        );
+        row++;
+        const lines = wrapText(c.body, w);
+        for (const line of lines) {
+          if (row > bottom) return;
+          term.moveTo(1, row);
+          term(line);
+          row++;
+        }
+        if (row > bottom) return;
+        row++; // blank between comments
+      }
+    }
+  }
+
+  renderNotificationFallback(n: Notification, bottom: number, w: number): void {
+    let row = 1;
+    term.moveTo(1, row);
+    term.bold.cyan(truncate(n.title, w));
+    row++;
+    if (n.subtitle) {
+      term.moveTo(1, row);
+      term.dim(truncate(n.subtitle, w));
+      row++;
+    }
+    row++;
+    row = drawLabeledRows(row, bottom, metadataRows(n));
+
+    if (n.comment?.body && row + 1 <= bottom) {
+      row++;
+      term.moveTo(1, row);
+      term.bold("Comment");
+      row++;
+      const lines = wrapText(n.comment.body, w);
+      for (const line of lines) {
+        if (row > bottom) return;
+        term.moveTo(1, row);
+        term(line);
+        row++;
+      }
+    }
+  }
+
+  openCurrent(): void {
+    const n = this.current();
+    if (!n) return;
+
+    this.mode = "issue";
+    this.issueStatus = "";
+    this.issue = null;
+    this.issueError = null;
+
+    if (!n.issue) {
+      // No associated issue — show fallback immediately
+      this.issueLoading = false;
+      this.render();
+      return;
+    }
+
+    const cached = this.issueCache.get(n.issue.identifier);
+    if (cached) {
+      this.issue = cached;
+      this.issueLoading = false;
+      this.render();
+      return;
+    }
+
+    this.issueLoading = true;
+    this.render();
+
+    try {
+      const issue = fetchIssue(n.issue.identifier);
+      this.issueCache.set(n.issue.identifier, issue);
+      this.issue = issue;
+      this.issueError = null;
+    } catch (err) {
+      this.issueError = `Error loading issue: ${err}`;
+    } finally {
+      this.issueLoading = false;
+    }
     this.render();
   }
 
-  leaveDetails(): void {
+  backToList(): void {
     this.mode = "list";
+    this.issue = null;
+    this.issueError = null;
+    this.issueLoading = false;
     this.render();
   }
 
   removeCurrent(): boolean {
-    this.notifications.splice(this.selected, 1);
+    const removed = this.notifications.splice(this.selected, 1)[0];
+    if (removed?.issue) this.issueCache.delete(removed.issue.identifier);
     if (this.notifications.length === 0) return false;
     this.selected = Math.min(this.selected, this.notifications.length - 1);
     this.listStatus = countStatus(this.notifications.length);
@@ -302,7 +569,11 @@ class App {
     this.render();
     try {
       this.notifications = fetchUnreadNotifications();
-      this.selected = Math.min(this.selected, Math.max(0, this.notifications.length - 1));
+      this.issueCache.clear();
+      this.selected = Math.min(
+        this.selected,
+        Math.max(0, this.notifications.length - 1)
+      );
       this.listStatus = countStatus(this.notifications.length);
     } catch (err) {
       this.listStatus = `Error reloading: ${err}`;
@@ -357,7 +628,7 @@ async function main(): Promise<void> {
     if (app.mode === "list") {
       handleListKey(app, key);
     } else {
-      handleDetailsKey(app, key);
+      handleIssueKey(app, key);
     }
   });
 }
@@ -382,7 +653,8 @@ function handleListKey(app: App, key: string): void {
       return;
 
     case "ENTER":
-      if (app.current()) app.enterDetails();
+    case "o":
+      if (app.current()) app.openCurrent();
       return;
 
     case "b": {
@@ -422,19 +694,21 @@ function handleListKey(app: App, key: string): void {
   }
 }
 
-function handleDetailsKey(app: App, key: string): void {
+function handleIssueKey(app: App, key: string): void {
   switch (key) {
+    case "u":
     case "q":
     case "ESCAPE":
     case "ENTER":
-      app.leaveDetails();
+      app.backToList();
       return;
 
     case "b": {
       const n = app.current();
-      if (n?.url) {
-        openUrl(n.url);
-        app.detailsStatus = "Opened in browser";
+      const url = app.issue?.url ?? n?.url;
+      if (url) {
+        openUrl(url);
+        app.issueStatus = "Opened in browser";
         app.render();
       }
       return;
@@ -443,7 +717,7 @@ function handleDetailsKey(app: App, key: string): void {
     case "m": {
       const n = app.current();
       if (!n) return;
-      app.detailsStatus = "Marking as read…";
+      app.issueStatus = "Marking as read…";
       app.render();
       try {
         markNotificationRead(n.id);
@@ -451,9 +725,9 @@ function handleDetailsKey(app: App, key: string): void {
           quit(0, "No unread notifications.\n");
           return;
         }
-        app.leaveDetails();
+        app.backToList();
       } catch (err) {
-        app.detailsStatus = `Error marking as read: ${err}`;
+        app.issueStatus = `Error marking as read: ${err}`;
         app.render();
       }
       return;

--- a/linear-notifications/src/index.ts
+++ b/linear-notifications/src/index.ts
@@ -40,12 +40,14 @@ interface Notification {
   readAt: string | null;
   url: string;
   actor: { name: string } | null;
+  issue?: { identifier: string; title: string } | null;
+  project?: { name: string } | null;
+  pullRequest?: { title: string; number: number; url: string } | null;
+  comment?: { body: string } | null;
 }
 
-function fetchUnreadNotifications(): Notification[] {
-  const result = spawnSync("linear", ["api", GRAPHQL_QUERY], {
-    encoding: "utf8",
-  });
+function runLinearApi(query: string): any {
+  const result = spawnSync("linear", ["api", query], { encoding: "utf8" });
 
   if (result.error) {
     throw new Error(`Failed to run linear CLI: ${result.error.message}`);
@@ -57,15 +59,32 @@ function fetchUnreadNotifications(): Notification[] {
   }
 
   const data = JSON.parse(result.stdout);
+  if (data.errors) {
+    throw new Error(`GraphQL error: ${JSON.stringify(data.errors)}`);
+  }
+  return data;
+}
+
+function fetchUnreadNotifications(): Notification[] {
+  const data = runLinearApi(GRAPHQL_QUERY);
   const nodes: Notification[] = data?.data?.notifications?.nodes ?? [];
   return nodes.filter((n) => n.readAt === null);
+}
+
+function markNotificationRead(id: string): void {
+  const now = new Date().toISOString();
+  const mutation = `mutation { notificationUpdate(id: "${id}", input: { readAt: "${now}" }) { success } }`;
+  const data = runLinearApi(mutation);
+  if (!data?.data?.notificationUpdate?.success) {
+    throw new Error("notificationUpdate returned success=false");
+  }
 }
 
 function openUrl(url: string): void {
   const platform = process.platform;
   const cmd =
     platform === "darwin" ? "open" : platform === "win32" ? "start" : "xdg-open";
-  spawnSync(cmd, [url], { stdio: "inherit" });
+  spawnSync(cmd, [url], { stdio: "ignore" });
 }
 
 function formatTime(iso: string): string {
@@ -86,6 +105,31 @@ function truncate(str: string, maxLen: number): string {
   return str.slice(0, maxLen - 1) + "…";
 }
 
+function wrapText(text: string, cols: number): string[] {
+  const out: string[] = [];
+  for (const paragraph of text.split("\n")) {
+    if (paragraph.length === 0) {
+      out.push("");
+      continue;
+    }
+    const words = paragraph.split(/\s+/);
+    let current = "";
+    for (const word of words) {
+      if (word.length === 0) continue;
+      if (current.length === 0) {
+        current = word;
+      } else if (current.length + 1 + word.length <= cols) {
+        current += " " + word;
+      } else {
+        out.push(current);
+        current = word;
+      }
+    }
+    if (current.length > 0) out.push(current);
+  }
+  return out;
+}
+
 // ANSI escape helpers
 const ESC = "\x1b";
 const HIDE_CURSOR = `${ESC}[?25l`;
@@ -96,7 +140,12 @@ const DIM = `${ESC}[2m`;
 const REVERSE = `${ESC}[7m`;
 const CYAN = `${ESC}[36m`;
 const CLEAR_LINE = `${ESC}[2K`;
+const CLEAR_SCREEN = `${ESC}[2J`;
+const MOVE_HOME = `${ESC}[H`;
+const ALT_SCREEN_ON = `${ESC}[?1049h`;
+const ALT_SCREEN_OFF = `${ESC}[?1049l`;
 const UP = (n: number) => `${ESC}[${n}A`;
+const MOVE_TO = (row: number, col: number) => `${ESC}[${row};${col}H`;
 
 const MAX_VISIBLE_ITEMS = 10;
 
@@ -121,7 +170,7 @@ function reserveArea(height: number): void {
  * After rendering, cursor is left at the top-left of the area so the next
  * render also starts there.
  */
-function render(
+function renderList(
   notifications: Notification[],
   selected: number,
   statusMsg: string
@@ -168,10 +217,65 @@ function render(
 
   // ── Help line ────────────────────────────────────────────────────────────
   out += CLEAR_LINE;
-  out += DIM + "↑↓/jk: navigate  Enter: open  r: reload  q/Esc: quit" + RESET;
+  out +=
+    DIM +
+    "↑↓/jk: navigate  Enter: details  b: browser  m: mark read  r: reload  q: quit" +
+    RESET;
 
   // Move cursor back to the top of the area for the next render
   out += UP(areaHeight - 1) + "\r";
+
+  process.stdout.write(out);
+}
+
+function renderDetails(n: Notification, statusMsg: string): void {
+  const termCols = process.stdout.columns ?? 80;
+  const termRows = process.stdout.rows ?? 24;
+
+  let out = CLEAR_SCREEN + MOVE_HOME;
+
+  out += `${BOLD}${CYAN}${truncate(n.title, termCols)}${RESET}\n`;
+  if (n.subtitle) out += `${DIM}${truncate(n.subtitle, termCols)}${RESET}\n`;
+  out += "\n";
+
+  const actor = n.actor?.name ?? "—";
+  const rows: Array<[string, string]> = [
+    ["Type", n.type],
+    ["Actor", actor],
+    ["Time", `${formatTime(n.createdAt)} (${n.createdAt})`],
+  ];
+  if (n.issue) rows.push(["Issue", `${n.issue.identifier} — ${n.issue.title}`]);
+  if (n.project) rows.push(["Project", n.project.name]);
+  if (n.pullRequest)
+    rows.push(["PR", `#${n.pullRequest.number} ${n.pullRequest.title}`]);
+  rows.push(["URL", n.url]);
+
+  const labelWidth = Math.max(...rows.map(([l]) => l.length));
+  for (const [label, value] of rows) {
+    const padded = (label + ":").padEnd(labelWidth + 2);
+    out += `${DIM}${padded}${RESET}${truncate(value, termCols - labelWidth - 2)}\n`;
+  }
+
+  if (n.comment?.body) {
+    out += "\n" + BOLD + "Comment" + RESET + "\n";
+    const lines = wrapText(n.comment.body, termCols);
+    // Leave 2 rows for the footer + blank line
+    const maxBodyRows = Math.max(0, termRows - 4 - rows.length - (n.subtitle ? 1 : 0) - 4);
+    for (const line of lines.slice(0, maxBodyRows)) {
+      out += line + "\n";
+    }
+    if (lines.length > maxBodyRows) {
+      out += DIM + `… (${lines.length - maxBodyRows} more line${lines.length - maxBodyRows !== 1 ? "s" : ""})` + RESET + "\n";
+    }
+  }
+
+  // Footer pinned to last row
+  out += MOVE_TO(termRows, 1) + CLEAR_LINE;
+  const help = "b: browser  m: mark read  Enter/q: back";
+  out += DIM + help + RESET;
+  if (statusMsg) {
+    out += `  ${CYAN}${statusMsg}${RESET}`;
+  }
 
   process.stdout.write(out);
 }
@@ -188,13 +292,6 @@ function clearArea(): void {
   }
   out += "\r";
   process.stdout.write(out);
-}
-
-function exit(stdin: NodeJS.ReadStream): void {
-  clearArea();
-  process.stdout.write(SHOW_CURSOR);
-  stdin.setRawMode(false);
-  process.exit(0);
 }
 
 async function main(): Promise<void> {
@@ -220,33 +317,98 @@ async function main(): Promise<void> {
   process.stdout.write(HIDE_CURSOR);
 
   let selected = 0;
-  let statusMsg = `${notifications.length} unread notification${notifications.length !== 1 ? "s" : ""}`;
+  let statusMsg = makeCountStatus(notifications.length);
+  let mode: "list" | "details" = "list";
+  let detailsStatus = "";
+
+  const unreadCountStatus = () => makeCountStatus(notifications.length);
+
+  function currentNotification(): Notification | null {
+    return notifications[selected] ?? null;
+  }
+
+  function renderCurrent(): void {
+    if (mode === "list") {
+      renderList(notifications, selected, statusMsg);
+    } else {
+      const n = currentNotification();
+      if (n) renderDetails(n, detailsStatus);
+    }
+  }
+
+  function enterDetails(): void {
+    mode = "details";
+    detailsStatus = "";
+    process.stdout.write(ALT_SCREEN_ON);
+    renderCurrent();
+  }
+
+  function leaveDetails(): void {
+    mode = "list";
+    process.stdout.write(ALT_SCREEN_OFF);
+    renderCurrent();
+  }
+
+  function exitApp(): void {
+    if (mode === "details") {
+      process.stdout.write(ALT_SCREEN_OFF);
+    }
+    clearArea();
+    process.stdout.write(SHOW_CURSOR);
+    stdin.setRawMode(false);
+    process.exit(0);
+  }
+
+  function removeCurrentAndRefresh(): void {
+    notifications.splice(selected, 1);
+    if (notifications.length === 0) {
+      // No more notifications — exit cleanly
+      if (mode === "details") {
+        process.stdout.write(ALT_SCREEN_OFF);
+      }
+      clearArea();
+      process.stdout.write(SHOW_CURSOR);
+      stdin.setRawMode(false);
+      process.stdout.write("No unread notifications.\n");
+      process.exit(0);
+    }
+    selected = Math.min(selected, notifications.length - 1);
+    statusMsg = unreadCountStatus();
+  }
 
   const visibleItems = computeVisibleItems(notifications.length);
   reserveArea(visibleItems + 2); // header + items + help
-  render(notifications, selected, statusMsg);
+  renderCurrent();
 
   process.stdout.on("resize", () => {
-    render(notifications, selected, statusMsg);
+    renderCurrent();
   });
 
   stdin.on("data", (key: string) => {
-    // Ctrl-C
+    // Ctrl-C always exits
     if (key === "\x03") {
-      exit(stdin);
+      exitApp();
       return;
     }
 
+    if (mode === "list") {
+      handleListKey(key);
+    } else {
+      handleDetailsKey(key);
+    }
+  });
+
+  function handleListKey(key: string): void {
     // q or Escape
     if (key === "q" || key === "\x1b") {
-      exit(stdin);
+      exitApp();
       return;
     }
 
     // r - reload
     if (key === "r") {
       statusMsg = "Reloading…";
-      render(notifications, selected, statusMsg);
+      renderCurrent();
       try {
         notifications = fetchUnreadNotifications();
         if (notifications.length === 0) {
@@ -257,41 +419,103 @@ async function main(): Promise<void> {
           process.exit(0);
         }
         selected = Math.min(selected, notifications.length - 1);
-        statusMsg = `${notifications.length} unread notification${notifications.length !== 1 ? "s" : ""}`;
+        statusMsg = unreadCountStatus();
       } catch (err) {
         statusMsg = `Error reloading: ${err}`;
       }
-      render(notifications, selected, statusMsg);
+      renderCurrent();
       return;
     }
 
     // Arrow up / k
     if (key === "\x1b[A" || key === "k") {
       selected = Math.max(0, selected - 1);
-      render(notifications, selected, statusMsg);
+      renderCurrent();
       return;
     }
 
     // Arrow down / j
     if (key === "\x1b[B" || key === "j") {
       selected = Math.min(notifications.length - 1, selected + 1);
-      render(notifications, selected, statusMsg);
+      renderCurrent();
       return;
     }
 
-    // Enter
+    // Enter - show details in full-screen
     if (key === "\r" || key === "\n") {
-      const n = notifications[selected];
-      if (n?.url) {
-        clearArea();
-        process.stdout.write(SHOW_CURSOR);
-        stdin.setRawMode(false);
-        openUrl(n.url);
-        process.exit(0);
+      if (currentNotification()) {
+        enterDetails();
       }
       return;
     }
-  });
+
+    // b - open in browser (stay in program)
+    if (key === "b") {
+      const n = currentNotification();
+      if (n?.url) {
+        openUrl(n.url);
+        statusMsg = `Opened in browser — ${unreadCountStatus()}`;
+        renderCurrent();
+      }
+      return;
+    }
+
+    // m - mark selected as read
+    if (key === "m") {
+      const n = currentNotification();
+      if (!n) return;
+      statusMsg = "Marking as read…";
+      renderCurrent();
+      try {
+        markNotificationRead(n.id);
+        removeCurrentAndRefresh();
+      } catch (err) {
+        statusMsg = `Error marking as read: ${err}`;
+      }
+      renderCurrent();
+      return;
+    }
+  }
+
+  function handleDetailsKey(key: string): void {
+    // Enter / q / Esc - back to list
+    if (key === "\r" || key === "\n" || key === "q" || key === "\x1b") {
+      leaveDetails();
+      return;
+    }
+
+    // b - open in browser (stay in details view)
+    if (key === "b") {
+      const n = currentNotification();
+      if (n?.url) {
+        openUrl(n.url);
+        detailsStatus = "Opened in browser";
+        renderCurrent();
+      }
+      return;
+    }
+
+    // m - mark as read, then return to list
+    if (key === "m") {
+      const n = currentNotification();
+      if (!n) return;
+      detailsStatus = "Marking as read…";
+      renderCurrent();
+      try {
+        markNotificationRead(n.id);
+        removeCurrentAndRefresh();
+        leaveDetails();
+      } catch (err) {
+        detailsStatus = `Error marking as read: ${err}`;
+        renderCurrent();
+      }
+      return;
+    }
+  }
+}
+
+function makeCountStatus(count: number): string {
+  return `${count} unread notification${count !== 1 ? "s" : ""}`;
 }
 
 main().catch((err) => {

--- a/linear-notifications/src/index.ts
+++ b/linear-notifications/src/index.ts
@@ -1,6 +1,9 @@
 #!/usr/bin/env node
 
 import { spawnSync } from "child_process";
+import termkit from "terminal-kit";
+
+const term = termkit.terminal;
 
 const GRAPHQL_QUERY = `query {
   notifications(first: 50) {
@@ -130,168 +133,192 @@ function wrapText(text: string, cols: number): string[] {
   return out;
 }
 
-// ANSI escape helpers
-const ESC = "\x1b";
-const HIDE_CURSOR = `${ESC}[?25l`;
-const SHOW_CURSOR = `${ESC}[?25h`;
-const RESET = `${ESC}[0m`;
-const BOLD = `${ESC}[1m`;
-const DIM = `${ESC}[2m`;
-const REVERSE = `${ESC}[7m`;
-const CYAN = `${ESC}[36m`;
-const CLEAR_LINE = `${ESC}[2K`;
-const CLEAR_SCREEN = `${ESC}[2J`;
-const MOVE_HOME = `${ESC}[H`;
-const ALT_SCREEN_ON = `${ESC}[?1049h`;
-const ALT_SCREEN_OFF = `${ESC}[?1049l`;
-const UP = (n: number) => `${ESC}[${n}A`;
-const MOVE_TO = (row: number, col: number) => `${ESC}[${row};${col}H`;
-
-const MAX_VISIBLE_ITEMS = 10;
-
-// The inline rendering area has a fixed height determined at startup:
-//   1 header line + visibleItems lines + 1 help line
-let areaHeight = 0;
-let scrollOffset = 0;
-
-function computeVisibleItems(count: number): number {
-  return Math.min(count, MAX_VISIBLE_ITEMS);
+function countStatus(count: number): string {
+  return `${count} unread notification${count !== 1 ? "s" : ""}`;
 }
 
-/** Reserve `areaHeight` blank lines below current cursor, then move back up. */
-function reserveArea(height: number): void {
-  areaHeight = height;
-  // Move cursor down by printing newlines (may scroll terminal), then back up
-  process.stdout.write("\n".repeat(height) + UP(height));
-}
+type Mode = "list" | "details";
 
-/**
- * Render the entire inline area in-place.
- * After rendering, cursor is left at the top-left of the area so the next
- * render also starts there.
- */
-function renderList(
-  notifications: Notification[],
-  selected: number,
-  statusMsg: string
-): void {
-  const termCols = process.stdout.columns ?? 80;
-  const visibleItems = computeVisibleItems(notifications.length);
+class App {
+  notifications: Notification[];
+  selected = 0;
+  scrollOffset = 0;
+  mode: Mode = "list";
+  listStatus: string;
+  detailsStatus = "";
 
-  // Adjust scroll to keep selected in view
-  if (selected < scrollOffset) {
-    scrollOffset = selected;
-  } else if (selected >= scrollOffset + visibleItems) {
-    scrollOffset = selected - visibleItems + 1;
+  constructor(notifications: Notification[]) {
+    this.notifications = notifications;
+    this.listStatus = countStatus(notifications.length);
   }
 
-  let out = "\r"; // go to column 1
+  current(): Notification | undefined {
+    return this.notifications[this.selected];
+  }
 
-  // ── Header ──────────────────────────────────────────────────────────────
-  out += CLEAR_LINE;
-  const headerText = `${BOLD}${CYAN}Linear Notifications${RESET} ${DIM}— ${statusMsg}${RESET}`;
-  out += headerText + "\n";
+  render(): void {
+    if (this.mode === "list") this.renderList();
+    else this.renderDetails();
+  }
 
-  // ── Item lines ───────────────────────────────────────────────────────────
-  for (let i = 0; i < visibleItems; i++) {
-    out += CLEAR_LINE;
-    const idx = i + scrollOffset;
-    const n = notifications[idx];
-    const isSelected = idx === selected;
+  renderList(): void {
+    term.clear();
+    term.moveTo(1, 1);
+    term.bold.cyan("Linear Notifications");
+    term(" ");
+    term.dim(`— ${this.listStatus}`);
 
-    const timeStr = formatTime(n.createdAt);
-    const timeWidth = 8;
-    const prefix = isSelected ? "▶ " : "  ";
-    const titleWidth = Math.max(0, termCols - timeWidth - prefix.length - 1);
-    const title = truncate(n.title, titleWidth);
-    const time = timeStr.padStart(timeWidth);
-    const line = `${prefix}${title.padEnd(titleWidth)} ${time}`;
+    const listTop = 3;
+    const listBottom = term.height - 1;
+    const maxItems = Math.max(1, listBottom - listTop + 1);
 
-    if (isSelected) {
-      out += REVERSE + BOLD + truncate(line, termCols).padEnd(termCols) + RESET;
-    } else {
-      out += line;
+    if (this.selected < this.scrollOffset) {
+      this.scrollOffset = this.selected;
+    } else if (this.selected >= this.scrollOffset + maxItems) {
+      this.scrollOffset = this.selected - maxItems + 1;
     }
-    out += "\n";
+
+    const timeW = 8;
+    const visible = Math.min(maxItems, this.notifications.length - this.scrollOffset);
+    for (let i = 0; i < visible; i++) {
+      const idx = i + this.scrollOffset;
+      const n = this.notifications[idx];
+      const isSelected = idx === this.selected;
+      const prefix = isSelected ? "▶ " : "  ";
+      const titleW = Math.max(0, term.width - timeW - prefix.length - 1);
+      const title = truncate(n.title, titleW).padEnd(titleW);
+      const time = formatTime(n.createdAt).padStart(timeW);
+      const line = `${prefix}${title} ${time}`;
+
+      term.moveTo(1, listTop + i);
+      const rowWidth = Math.max(0, term.width - 1);
+      if (isSelected) {
+        term.inverse.bold(truncate(line, rowWidth).padEnd(rowWidth));
+      } else {
+        term(truncate(line, rowWidth));
+      }
+    }
+
+    term.moveTo(1, term.height);
+    term.dim(
+      truncate(
+        "↑↓/jk: navigate  Enter: details  b: browser  m: mark read  r: reload  q: quit",
+        Math.max(0, term.width - 1)
+      )
+    );
   }
 
-  // ── Help line ────────────────────────────────────────────────────────────
-  out += CLEAR_LINE;
-  out +=
-    DIM +
-    "↑↓/jk: navigate  Enter: details  b: browser  m: mark read  r: reload  q: quit" +
-    RESET;
+  renderDetails(): void {
+    const n = this.current();
+    if (!n) return;
 
-  // Move cursor back to the top of the area for the next render
-  out += UP(areaHeight - 1) + "\r";
+    term.clear();
+    term.moveTo(1, 1);
+    term.bold.cyan(truncate(n.title, term.width));
 
-  process.stdout.write(out);
+    let row = 2;
+    if (n.subtitle) {
+      term.moveTo(1, row);
+      term.dim(truncate(n.subtitle, term.width));
+      row++;
+    }
+    row++; // blank line
+
+    const rows: Array<[string, string]> = [
+      ["Type", n.type],
+      ["Actor", n.actor?.name ?? "—"],
+      ["Time", `${formatTime(n.createdAt)} (${n.createdAt})`],
+    ];
+    if (n.issue)
+      rows.push(["Issue", `${n.issue.identifier} — ${n.issue.title}`]);
+    if (n.project) rows.push(["Project", n.project.name]);
+    if (n.pullRequest)
+      rows.push(["PR", `#${n.pullRequest.number} ${n.pullRequest.title}`]);
+    rows.push(["URL", n.url]);
+
+    const labelW = Math.max(...rows.map(([l]) => l.length)) + 2;
+    for (const [label, value] of rows) {
+      term.moveTo(1, row);
+      term.dim((label + ":").padEnd(labelW));
+      term(truncate(value, Math.max(0, term.width - labelW)));
+      row++;
+    }
+
+    if (n.comment?.body) {
+      row++; // blank line
+      term.moveTo(1, row);
+      term.bold("Comment");
+      row++;
+
+      const footerRow = term.height;
+      const maxBodyRows = Math.max(0, footerRow - row - 1);
+      const bodyLines = wrapText(n.comment.body, term.width);
+      const shown = bodyLines.slice(0, maxBodyRows);
+      for (const line of shown) {
+        term.moveTo(1, row);
+        term(line);
+        row++;
+      }
+      if (bodyLines.length > shown.length) {
+        term.moveTo(1, row);
+        term.dim(
+          `… (${bodyLines.length - shown.length} more line${
+            bodyLines.length - shown.length !== 1 ? "s" : ""
+          })`
+        );
+      }
+    }
+
+    term.moveTo(1, term.height);
+    const footerW = Math.max(0, term.width - 1);
+    const help = "b: browser  m: mark read  Enter/q: back";
+    const footer = this.detailsStatus
+      ? `${help}  ${this.detailsStatus}`
+      : help;
+    term.dim(truncate(footer, footerW));
+  }
+
+  enterDetails(): void {
+    this.mode = "details";
+    this.detailsStatus = "";
+    this.render();
+  }
+
+  leaveDetails(): void {
+    this.mode = "list";
+    this.render();
+  }
+
+  removeCurrent(): boolean {
+    this.notifications.splice(this.selected, 1);
+    if (this.notifications.length === 0) return false;
+    this.selected = Math.min(this.selected, this.notifications.length - 1);
+    this.listStatus = countStatus(this.notifications.length);
+    return true;
+  }
+
+  reload(): void {
+    this.listStatus = "Reloading…";
+    this.render();
+    try {
+      this.notifications = fetchUnreadNotifications();
+      this.selected = Math.min(this.selected, Math.max(0, this.notifications.length - 1));
+      this.listStatus = countStatus(this.notifications.length);
+    } catch (err) {
+      this.listStatus = `Error reloading: ${err}`;
+    }
+    this.render();
+  }
 }
 
-function renderDetails(n: Notification, statusMsg: string): void {
-  const termCols = process.stdout.columns ?? 80;
-  const termRows = process.stdout.rows ?? 24;
-
-  let out = CLEAR_SCREEN + MOVE_HOME;
-
-  out += `${BOLD}${CYAN}${truncate(n.title, termCols)}${RESET}\n`;
-  if (n.subtitle) out += `${DIM}${truncate(n.subtitle, termCols)}${RESET}\n`;
-  out += "\n";
-
-  const actor = n.actor?.name ?? "—";
-  const rows: Array<[string, string]> = [
-    ["Type", n.type],
-    ["Actor", actor],
-    ["Time", `${formatTime(n.createdAt)} (${n.createdAt})`],
-  ];
-  if (n.issue) rows.push(["Issue", `${n.issue.identifier} — ${n.issue.title}`]);
-  if (n.project) rows.push(["Project", n.project.name]);
-  if (n.pullRequest)
-    rows.push(["PR", `#${n.pullRequest.number} ${n.pullRequest.title}`]);
-  rows.push(["URL", n.url]);
-
-  const labelWidth = Math.max(...rows.map(([l]) => l.length));
-  for (const [label, value] of rows) {
-    const padded = (label + ":").padEnd(labelWidth + 2);
-    out += `${DIM}${padded}${RESET}${truncate(value, termCols - labelWidth - 2)}\n`;
+function quit(code: number = 0, finalMessage?: string): void {
+  term.hideCursor(false);
+  term.grabInput(false);
+  term.fullscreen(false);
+  if (finalMessage) {
+    process.stdout.write(finalMessage);
   }
-
-  if (n.comment?.body) {
-    out += "\n" + BOLD + "Comment" + RESET + "\n";
-    const lines = wrapText(n.comment.body, termCols);
-    // Leave 2 rows for the footer + blank line
-    const maxBodyRows = Math.max(0, termRows - 4 - rows.length - (n.subtitle ? 1 : 0) - 4);
-    for (const line of lines.slice(0, maxBodyRows)) {
-      out += line + "\n";
-    }
-    if (lines.length > maxBodyRows) {
-      out += DIM + `… (${lines.length - maxBodyRows} more line${lines.length - maxBodyRows !== 1 ? "s" : ""})` + RESET + "\n";
-    }
-  }
-
-  // Footer pinned to last row
-  out += MOVE_TO(termRows, 1) + CLEAR_LINE;
-  const help = "b: browser  m: mark read  Enter/q: back";
-  out += DIM + help + RESET;
-  if (statusMsg) {
-    out += `  ${CYAN}${statusMsg}${RESET}`;
-  }
-
-  process.stdout.write(out);
-}
-
-/** Clear all lines in the reserved area and leave cursor at the top. */
-function clearArea(): void {
-  let out = "\r";
-  for (let i = 0; i < areaHeight; i++) {
-    out += CLEAR_LINE;
-    if (i < areaHeight - 1) out += "\n";
-  }
-  if (areaHeight > 1) {
-    out += UP(areaHeight - 1);
-  }
-  out += "\r";
-  process.stdout.write(out);
+  process.exit(code);
 }
 
 async function main(): Promise<void> {
@@ -309,216 +336,135 @@ async function main(): Promise<void> {
     process.exit(0);
   }
 
-  const stdin = process.stdin;
-  stdin.setRawMode(true);
-  stdin.resume();
-  stdin.setEncoding("utf8");
+  const app = new App(notifications);
 
-  process.stdout.write(HIDE_CURSOR);
+  term.fullscreen(true);
+  term.grabInput(true);
+  term.hideCursor(true);
 
-  let selected = 0;
-  let statusMsg = makeCountStatus(notifications.length);
-  let mode: "list" | "details" = "list";
-  let detailsStatus = "";
+  app.render();
 
-  const unreadCountStatus = () => makeCountStatus(notifications.length);
+  term.on("resize", () => {
+    app.render();
+  });
 
-  function currentNotification(): Notification | null {
-    return notifications[selected] ?? null;
-  }
+  term.on("key", (key: string) => {
+    if (key === "CTRL_C") {
+      quit(0);
+      return;
+    }
 
-  function renderCurrent(): void {
-    if (mode === "list") {
-      renderList(notifications, selected, statusMsg);
+    if (app.mode === "list") {
+      handleListKey(app, key);
     } else {
-      const n = currentNotification();
-      if (n) renderDetails(n, detailsStatus);
+      handleDetailsKey(app, key);
     }
-  }
+  });
+}
 
-  function enterDetails(): void {
-    mode = "details";
-    detailsStatus = "";
-    process.stdout.write(ALT_SCREEN_ON);
-    renderCurrent();
-  }
+function handleListKey(app: App, key: string): void {
+  switch (key) {
+    case "q":
+    case "ESCAPE":
+      quit(0);
+      return;
 
-  function leaveDetails(): void {
-    mode = "list";
-    process.stdout.write(ALT_SCREEN_OFF);
-    renderCurrent();
-  }
+    case "UP":
+    case "k":
+      app.selected = Math.max(0, app.selected - 1);
+      app.render();
+      return;
 
-  function exitApp(): void {
-    if (mode === "details") {
-      process.stdout.write(ALT_SCREEN_OFF);
-    }
-    clearArea();
-    process.stdout.write(SHOW_CURSOR);
-    stdin.setRawMode(false);
-    process.exit(0);
-  }
+    case "DOWN":
+    case "j":
+      app.selected = Math.min(app.notifications.length - 1, app.selected + 1);
+      app.render();
+      return;
 
-  function removeCurrentAndRefresh(): void {
-    notifications.splice(selected, 1);
-    if (notifications.length === 0) {
-      // No more notifications — exit cleanly
-      if (mode === "details") {
-        process.stdout.write(ALT_SCREEN_OFF);
+    case "ENTER":
+      if (app.current()) app.enterDetails();
+      return;
+
+    case "b": {
+      const n = app.current();
+      if (n?.url) {
+        openUrl(n.url);
+        app.listStatus = `Opened in browser — ${countStatus(app.notifications.length)}`;
+        app.render();
       }
-      clearArea();
-      process.stdout.write(SHOW_CURSOR);
-      stdin.setRawMode(false);
-      process.stdout.write("No unread notifications.\n");
-      process.exit(0);
-    }
-    selected = Math.min(selected, notifications.length - 1);
-    statusMsg = unreadCountStatus();
-  }
-
-  const visibleItems = computeVisibleItems(notifications.length);
-  reserveArea(visibleItems + 2); // header + items + help
-  renderCurrent();
-
-  process.stdout.on("resize", () => {
-    renderCurrent();
-  });
-
-  stdin.on("data", (key: string) => {
-    // Ctrl-C always exits
-    if (key === "\x03") {
-      exitApp();
       return;
     }
 
-    if (mode === "list") {
-      handleListKey(key);
-    } else {
-      handleDetailsKey(key);
-    }
-  });
-
-  function handleListKey(key: string): void {
-    // q or Escape
-    if (key === "q" || key === "\x1b") {
-      exitApp();
-      return;
-    }
-
-    // r - reload
-    if (key === "r") {
-      statusMsg = "Reloading…";
-      renderCurrent();
+    case "m": {
+      const n = app.current();
+      if (!n) return;
+      app.listStatus = "Marking as read…";
+      app.render();
       try {
-        notifications = fetchUnreadNotifications();
-        if (notifications.length === 0) {
-          clearArea();
-          process.stdout.write(SHOW_CURSOR);
-          stdin.setRawMode(false);
-          process.stdout.write("No unread notifications.\n");
-          process.exit(0);
+        markNotificationRead(n.id);
+        if (!app.removeCurrent()) {
+          quit(0, "No unread notifications.\n");
+          return;
         }
-        selected = Math.min(selected, notifications.length - 1);
-        statusMsg = unreadCountStatus();
       } catch (err) {
-        statusMsg = `Error reloading: ${err}`;
+        app.listStatus = `Error marking as read: ${err}`;
       }
-      renderCurrent();
+      app.render();
       return;
     }
 
-    // Arrow up / k
-    if (key === "\x1b[A" || key === "k") {
-      selected = Math.max(0, selected - 1);
-      renderCurrent();
-      return;
-    }
-
-    // Arrow down / j
-    if (key === "\x1b[B" || key === "j") {
-      selected = Math.min(notifications.length - 1, selected + 1);
-      renderCurrent();
-      return;
-    }
-
-    // Enter - show details in full-screen
-    if (key === "\r" || key === "\n") {
-      if (currentNotification()) {
-        enterDetails();
+    case "r":
+      app.reload();
+      if (app.notifications.length === 0) {
+        quit(0, "No unread notifications.\n");
       }
       return;
-    }
-
-    // b - open in browser (stay in program)
-    if (key === "b") {
-      const n = currentNotification();
-      if (n?.url) {
-        openUrl(n.url);
-        statusMsg = `Opened in browser — ${unreadCountStatus()}`;
-        renderCurrent();
-      }
-      return;
-    }
-
-    // m - mark selected as read
-    if (key === "m") {
-      const n = currentNotification();
-      if (!n) return;
-      statusMsg = "Marking as read…";
-      renderCurrent();
-      try {
-        markNotificationRead(n.id);
-        removeCurrentAndRefresh();
-      } catch (err) {
-        statusMsg = `Error marking as read: ${err}`;
-      }
-      renderCurrent();
-      return;
-    }
-  }
-
-  function handleDetailsKey(key: string): void {
-    // Enter / q / Esc - back to list
-    if (key === "\r" || key === "\n" || key === "q" || key === "\x1b") {
-      leaveDetails();
-      return;
-    }
-
-    // b - open in browser (stay in details view)
-    if (key === "b") {
-      const n = currentNotification();
-      if (n?.url) {
-        openUrl(n.url);
-        detailsStatus = "Opened in browser";
-        renderCurrent();
-      }
-      return;
-    }
-
-    // m - mark as read, then return to list
-    if (key === "m") {
-      const n = currentNotification();
-      if (!n) return;
-      detailsStatus = "Marking as read…";
-      renderCurrent();
-      try {
-        markNotificationRead(n.id);
-        removeCurrentAndRefresh();
-        leaveDetails();
-      } catch (err) {
-        detailsStatus = `Error marking as read: ${err}`;
-        renderCurrent();
-      }
-      return;
-    }
   }
 }
 
-function makeCountStatus(count: number): string {
-  return `${count} unread notification${count !== 1 ? "s" : ""}`;
+function handleDetailsKey(app: App, key: string): void {
+  switch (key) {
+    case "q":
+    case "ESCAPE":
+    case "ENTER":
+      app.leaveDetails();
+      return;
+
+    case "b": {
+      const n = app.current();
+      if (n?.url) {
+        openUrl(n.url);
+        app.detailsStatus = "Opened in browser";
+        app.render();
+      }
+      return;
+    }
+
+    case "m": {
+      const n = app.current();
+      if (!n) return;
+      app.detailsStatus = "Marking as read…";
+      app.render();
+      try {
+        markNotificationRead(n.id);
+        if (!app.removeCurrent()) {
+          quit(0, "No unread notifications.\n");
+          return;
+        }
+        app.leaveDetails();
+      } catch (err) {
+        app.detailsStatus = `Error marking as read: ${err}`;
+        app.render();
+      }
+      return;
+    }
+  }
 }
 
 main().catch((err) => {
+  term.hideCursor(false);
+  term.grabInput(false);
+  term.fullscreen(false);
   process.stderr.write(`Fatal error: ${err}\n`);
   process.exit(1);
 });


### PR DESCRIPTION
## Summary

This PR significantly enhances the notification viewer with a full-screen details view and the ability to mark notifications as read directly from the app, without needing to open them in a browser.

## Key Changes

- **Details view**: Press `Enter` to open a full-screen view of the selected notification showing title, subtitle, type, actor, timestamp, issue/project/PR info, and comment body with text wrapping
- **Mark as read**: Press `m` to mark the selected notification as read, which calls the Linear API mutation and removes it from the list
- **Browser action**: Press `b` to open the notification URL in the browser while staying in the app (previously `Enter` would exit)
- **Refactored API layer**: Extracted `runLinearApi()` helper to handle both queries and mutations with consistent error handling
- **Enhanced Notification type**: Added optional fields for `issue`, `project`, `pullRequest`, and `comment` to support the details view
- **Text wrapping utility**: Added `wrapText()` function to intelligently wrap long text to terminal width while preserving paragraphs
- **Terminal control improvements**: Added ANSI escape sequences for alternate screen buffer (`ALT_SCREEN_ON/OFF`), screen clearing, and cursor positioning to support the full-screen details view
- **Mode-based input handling**: Split keyboard handling into `handleListKey()` and `handleDetailsKey()` to support different actions in each view
- **Updated help text**: Changed from "Enter: open" to "Enter: details" and added new key bindings to the help line

## Implementation Details

- The details view uses the alternate screen buffer to avoid disrupting the terminal history
- Text wrapping respects paragraph breaks and word boundaries
- The app maintains state for both list and details views, allowing seamless navigation between them
- Marking a notification as read removes it from the list and updates the count; if all notifications are read, the app exits cleanly
- The `openUrl()` function now uses `stdio: "ignore"` instead of `stdio: "inherit"` to prevent browser output from interfering with the TUI

https://claude.ai/code/session_01RmazWNpMUPsrJpZJ2Foj4H