### PR TITLE
Add --check flag to install.sh for testing before installation

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -3,6 +3,40 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
+CHECK=0
+for arg in "$@"; do
+    case "$arg" in
+        --check)
+            CHECK=1
+            ;;
+        *)
+            echo "Unknown argument: $arg" >&2
+            echo "Usage: $0 [--check]" >&2
+            exit 1
+            ;;
+    esac
+done
+
+check-node() {
+    local dir="$1"
+    echo "==> Testing $dir"
+    (
+        cd "$SCRIPT_DIR/$dir"
+        pnpm install
+        if node -e "const p=require('./package.json'); process.exit(p.scripts && p.scripts.test ? 0 : 1)"; then
+            pnpm test
+        else
+            echo "    (no test script defined, skipping)"
+        fi
+    )
+}
+
+check-rust() {
+    local dir="$1"
+    echo "==> Testing $dir"
+    (cd "$SCRIPT_DIR/$dir" && cargo test)
+}
+
 install-node() {
     local dir="$1"
     echo "==> Installing $dir"
@@ -20,11 +54,23 @@ install-rust() {
     (cd "$SCRIPT_DIR/$dir" && cargo install --path .)
 }
 
-install-node linear-notifications
-install-node cloudwatch-insights
+NODE_TOOLS=(linear-notifications cloudwatch-insights)
+RUST_TOOLS=(git-dirty-checker log-jsonify x-java-home)
 
-install-rust git-dirty-checker
-install-rust log-jsonify
-install-rust x-java-home
+if [[ $CHECK -eq 1 ]]; then
+    for tool in "${NODE_TOOLS[@]}"; do
+        check-node "$tool"
+    done
+    for tool in "${RUST_TOOLS[@]}"; do
+        check-rust "$tool"
+    done
+fi
+
+for tool in "${NODE_TOOLS[@]}"; do
+    install-node "$tool"
+done
+for tool in "${RUST_TOOLS[@]}"; do
+    install-rust "$tool"
+done
 
 echo "==> Done"


### PR DESCRIPTION
## Summary
Enhanced the install.sh script to support a `--check` flag that runs tests for all tools before installing them, improving the development workflow by allowing validation of the codebase prior to installation.

## Key Changes
- Added command-line argument parsing to support a `--check` flag
- Implemented `check-node()` function that runs `pnpm install` and `pnpm test` (if a test script is defined) for Node.js tools
- Implemented `check-rust()` function that runs `cargo test` for Rust tools
- Refactored tool lists into arrays (`NODE_TOOLS` and `RUST_TOOLS`) for better maintainability
- Added conditional logic to run tests when `--check` flag is provided, before proceeding with installation
- Maintained backward compatibility: running without arguments performs the original installation behavior

## Implementation Details
- The check functions follow the same directory structure and patterns as the install functions
- Node.js test execution is conditional—it only runs if a test script is defined in package.json
- Error handling is preserved with `set -euo pipefail` at the script level
- Tool lists are centralized, making it easier to add or remove tools in the future

https://claude.ai/code/session_01VJWnjRJcBEhXWwQUvTbrgQ