### PR TITLE
Add support for selective tool installation in install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -4,15 +4,19 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 CHECK=0
+REQUESTED_TOOLS=()
 for arg in "$@"; do
     case "$arg" in
         --check)
             CHECK=1
             ;;
-        *)
+        -*)
             echo "Unknown argument: $arg" >&2
-            echo "Usage: $0 [--check]" >&2
+            echo "Usage: $0 [--check] [tool ...]" >&2
             exit 1
+            ;;
+        *)
+            REQUESTED_TOOLS+=("$arg")
             ;;
     esac
 done
@@ -57,19 +61,55 @@ install-rust() {
 NODE_TOOLS=(linear-notifications cloudwatch-insights)
 RUST_TOOLS=(git-dirty-checker log-jsonify x-java-home)
 
+tool-kind() {
+    local tool="$1"
+    for t in "${NODE_TOOLS[@]}"; do
+        if [[ "$t" == "$tool" ]]; then
+            echo "node"
+            return 0
+        fi
+    done
+    for t in "${RUST_TOOLS[@]}"; do
+        if [[ "$t" == "$tool" ]]; then
+            echo "rust"
+            return 0
+        fi
+    done
+    return 1
+}
+
+if [[ ${#REQUESTED_TOOLS[@]} -gt 0 ]]; then
+    SELECTED_NODE_TOOLS=()
+    SELECTED_RUST_TOOLS=()
+    for tool in "${REQUESTED_TOOLS[@]}"; do
+        kind="$(tool-kind "$tool")" || {
+            echo "Unknown tool: $tool" >&2
+            echo "Available tools: ${NODE_TOOLS[*]} ${RUST_TOOLS[*]}" >&2
+            exit 1
+        }
+        case "$kind" in
+            node) SELECTED_NODE_TOOLS+=("$tool") ;;
+            rust) SELECTED_RUST_TOOLS+=("$tool") ;;
+        esac
+    done
+else
+    SELECTED_NODE_TOOLS=("${NODE_TOOLS[@]}")
+    SELECTED_RUST_TOOLS=("${RUST_TOOLS[@]}")
+fi
+
 if [[ $CHECK -eq 1 ]]; then
-    for tool in "${NODE_TOOLS[@]}"; do
+    for tool in "${SELECTED_NODE_TOOLS[@]}"; do
         check-node "$tool"
     done
-    for tool in "${RUST_TOOLS[@]}"; do
+    for tool in "${SELECTED_RUST_TOOLS[@]}"; do
         check-rust "$tool"
     done
 fi
 
-for tool in "${NODE_TOOLS[@]}"; do
+for tool in "${SELECTED_NODE_TOOLS[@]}"; do
     install-node "$tool"
 done
-for tool in "${RUST_TOOLS[@]}"; do
+for tool in "${SELECTED_RUST_TOOLS[@]}"; do
     install-rust "$tool"
 done
 


### PR DESCRIPTION
## Summary
Enhanced the install.sh script to support installing individual tools instead of always installing all tools. Users can now specify which tools to install as command-line arguments while maintaining backward compatibility with the existing `--check` flag.

## Key Changes
- **Argument parsing**: Modified argument handling to distinguish between flags (starting with `-`) and tool names
  - Flags like `--check` are processed as options
  - Non-flag arguments are collected as requested tools
  - Updated usage message to reflect new syntax: `[--check] [tool ...]`

- **Tool selection logic**: Added `tool-kind()` helper function to identify whether a tool is Node-based or Rust-based

- **Conditional tool installation**: Implemented logic to:
  - Use all available tools if no specific tools are requested (preserves existing behavior)
  - Filter to only requested tools if arguments are provided
  - Validate requested tools and provide helpful error messages listing available tools

- **Consistent tool filtering**: Updated all tool installation and checking loops to use `SELECTED_NODE_TOOLS` and `SELECTED_RUST_TOOLS` arrays instead of the full tool lists

## Notable Implementation Details
- The script maintains full backward compatibility: running `./install.sh` or `./install.sh --check` behaves exactly as before
- Invalid tool names are caught early with a clear error message showing available options
- The implementation uses bash arrays and loops, consistent with the existing code style

https://claude.ai/code/session_01UT4H5oMGd6Fo8x5xKELNXk