### PR TITLE
Add CI/CD workflow for automated testing

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,66 @@
+name: Tests
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  rust:
+    name: cargo test (${{ matrix.tool }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        tool:
+          - git-dirty-checker
+          - log-jsonify
+          - x-java-home
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: ${{ matrix.tool }}
+      - name: cargo test
+        working-directory: ${{ matrix.tool }}
+        run: cargo test --verbose
+
+  node:
+    name: pnpm test (${{ matrix.tool }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        tool:
+          - cloudwatch-insights
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+          cache-dependency-path: ${{ matrix.tool }}/pnpm-lock.yaml
+      - name: pnpm install
+        working-directory: ${{ matrix.tool }}
+        run: pnpm install --frozen-lockfile
+      - name: pnpm test
+        working-directory: ${{ matrix.tool }}
+        run: pnpm test
+
+  java:
+    name: mvn test (git-repos-latest-activity)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '25'
+          cache: maven
+      - name: mvn test
+        working-directory: git-repos-latest-activity
+        run: mvn --batch-mode test


### PR DESCRIPTION
## Summary
This PR introduces a GitHub Actions workflow to automatically run tests across the monorepo's multiple language ecosystems on every pull request and push to main.

## Key Changes
- Added `.github/workflows/tests.yml` with three separate test jobs:
  - **Rust job**: Runs `cargo test` for three Rust tools (git-dirty-checker, log-jsonify, x-java-home) with caching
  - **Node.js job**: Runs `pnpm test` for the cloudwatch-insights tool with Node.js 22 and pnpm v10
  - **Java job**: Runs `mvn test` for the git-repos-latest-activity tool with Java 25

## Implementation Details
- Uses matrix strategy for Rust and Node.js jobs to test multiple tools in parallel
- Configured with `fail-fast: false` to ensure all tools are tested even if one fails
- Includes appropriate caching strategies for each ecosystem (rust-cache, pnpm cache, Maven cache)
- Triggers on pull requests and pushes to the main branch
- Each job runs on ubuntu-latest with appropriate toolchain setup actions

https://claude.ai/code/session_01F8tF9bqdxthib62C8vvJ67