### PR TITLE
Add inline detail view and field management UI

### DIFF
--- a/log-viewer/README.md
+++ b/log-viewer/README.md
@@ -294,6 +294,7 @@ In the detail view:
 |-----|--------|
 | `j` / `↓` | Move down (entry header → first field → next field, …) |
 | `k` / `↑` | Move up |
+| `n` / `p` | Next / previous entry (stay in detail) |
 | `c` | Copy the selected field's value, or the full JSON when the entry header is selected |
 | `t` | Toggle visibility of the selected field in the main list |
 | `v` | Open the fields menu |
@@ -307,7 +308,7 @@ In the fields menu:
 
 | Key | Action |
 |-----|--------|
-| `j` / `↓`, `k` / `↑` | Move the cursor |
+| `j` / `↓`, `k` / `↑` / `u` | Move the cursor |
 | `space` / `t` | Toggle the highlighted field's visibility |
 | `J` / `K` | Move the highlighted field down / up in the column order |
 | `v` / `q` / `Esc` | Close the menu |

--- a/log-viewer/README.md
+++ b/log-viewer/README.md
@@ -14,9 +14,19 @@ drill-down.
 - vi-like navigation in both: `j`/`k` (and arrows) move, `u` moves up, `o`
   (or Enter) opens the entry in detail view, `g`/`G` jump to top/bottom,
   `q`/Esc quits or closes the detail.
+- Detail view shows each field on its own row, so you can navigate
+  field-by-field, copy a single value, or toggle a field's visibility
+  in the main list with `t`.
+- Field management: `v` opens a menu listing every field ever seen,
+  with toggles for visibility and `J`/`K` to reorder columns. The
+  browser exposes the same menu as a popover with checkboxes and drag
+  reordering.
 - Configurable display fields and configurable default field name for
   non-JSON lines (matches the convention from
   [log-jsonify](../log-jsonify/)).
+- Named **profiles** in the config file, picked at startup with
+  `--profile <name>`, swap in different field layouts for different
+  log shapes (e.g. app logs vs. `kubectl`/`stern`).
 
 ## Install
 
@@ -156,6 +166,7 @@ Save it as `~/.skagedal-tools/log-viewer/config.json5` (or pass
 |------|-------------|
 | `-f`, `--file <path>` | Read JSONL from a file. Use `-` for stdin. |
 | `-c`, `--config <path>` | Path to a config file (overrides `~/.skagedal-tools/log-viewer/config.json5` and `$LOG_VIEWER_CONFIG`). |
+| `--profile <name>` | Activate a profile defined in the config file (overrides the top-level `fields` and optional `default_field`). |
 | `-e`, `--exec <cmd> [args...]` | Run an executable; its stdout is parsed as JSONL. **Every argv after the command is forwarded to it**, so `--exec kubectl logs -f my-pod` runs `kubectl logs -f my-pod`. Put log-viewer's own flags before `--exec`. |
 | `-b`, `--browser` | Start the browser app instead of the TUI. |
 | `-p`, `--port <n>` | Port for the browser server (default `5173`). |
@@ -267,8 +278,9 @@ In the list:
 | `j` / `↓` | Next entry |
 | `k` / `↑` | Previous entry |
 | `u` | Up one entry |
-| `o` / Enter | Open the selected entry (full JSON) |
+| `o` / Enter | Open the selected entry (field-row detail view) |
 | `f` | Toggle **follow** mode — pin selection to the latest entry as new ones arrive. Any navigation key turns it back off. |
+| `v` | Open the **fields menu** (toggle visibility, reorder columns). |
 | `g` / `G` | Top / bottom |
 | `q` / Ctrl-C | Quit (TUI only) |
 
@@ -280,7 +292,71 @@ In the detail view:
 
 | Key | Action |
 |-----|--------|
-| `j` / `↓` | Next entry (stay in detail) |
-| `k` / `↑` | Previous entry (stay in detail) |
-| `c` | Copy the entry's JSON to the system clipboard |
+| `j` / `↓` | Move down (entry header → first field → next field, …) |
+| `k` / `↑` | Move up |
+| `c` | Copy the selected field's value, or the full JSON when the entry header is selected |
+| `t` | Toggle visibility of the selected field in the main list |
+| `v` | Open the fields menu |
 | `u` / `Esc` / `q` | Back to the list |
+
+The browser shows the same expanded view inline under the clicked
+entry, with a checkbox next to each field for show/hide and a per-field
+"Copy" button.
+
+In the fields menu:
+
+| Key | Action |
+|-----|--------|
+| `j` / `↓`, `k` / `↑` | Move the cursor |
+| `space` / `t` | Toggle the highlighted field's visibility |
+| `J` / `K` | Move the highlighted field down / up in the column order |
+| `v` / `q` / `Esc` | Close the menu |
+
+In the browser, the same menu is available as a popover from the
+"Fields" button in the header. Toggle visibility with the checkbox,
+reorder with the up/down arrows or by drag-and-drop.
+
+## Profiles
+
+A profile is a named override for `fields` (and optionally
+`default_field`) that you can pick at startup:
+
+```json5
+{
+  fields: [
+    { name: "time", from: ["@timestamp"] },
+    { name: "level", from: ["level"] },
+    { name: "message", from: ["message"] },
+  ],
+
+  profiles: [
+    {
+      name: "stern",
+      fields: [
+        { name: "time",      from: ["timestamp"] },
+        { name: "namespace", from: ["namespace"] },
+        { name: "pod",       from: ["podName"] },
+        { name: "msg",       from: ["message"] },
+      ],
+    },
+    {
+      name: "wide",
+      fields: [
+        { name: "time",    from: ["@timestamp"] },
+        { name: "level",   from: ["level"] },
+        { name: "service", from: ["service"] },
+        { name: "host",    from: ["host", "hostname"] },
+        { name: "message", from: ["message"] },
+      ],
+    },
+  ],
+}
+```
+
+```bash
+log-viewer --profile stern --exec stern --output json my-app
+log-viewer --profile wide app.jsonl
+```
+
+Profiles only override the field layout — triggers and the rest of the
+config still apply. Unknown profile names exit with a non-zero status.

--- a/log-viewer/src/config.ts
+++ b/log-viewer/src/config.ts
@@ -34,10 +34,17 @@ export interface FieldConfig {
   from: string[];
 }
 
+export interface Profile {
+  name: string;
+  fields?: FieldConfig[];
+  defaultField?: string;
+}
+
 export interface Config {
   fields: FieldConfig[];
   defaultField: string;
   triggers: TriggerConfig[];
+  profiles: Profile[];
 }
 
 export const DEFAULT_CONFIG: Config = {
@@ -48,6 +55,7 @@ export const DEFAULT_CONFIG: Config = {
   ],
   defaultField: "message",
   triggers: [],
+  profiles: [],
 };
 
 export class ConfigError extends Error {
@@ -87,7 +95,42 @@ export function parseConfig(source: string): Config {
   const defaultField =
     typeof doc.default_field === "string" ? doc.default_field : DEFAULT_CONFIG.defaultField;
   const triggers = parseTriggers(doc.triggers);
-  return { fields, defaultField, triggers };
+  const profiles = parseProfiles(doc.profiles);
+  return { fields, defaultField, triggers, profiles };
+}
+
+function parseProfiles(value: unknown): Profile[] {
+  if (!Array.isArray(value)) return [];
+  const out: Profile[] = [];
+  for (const entry of value) {
+    if (!entry || typeof entry !== "object") continue;
+    const e = entry as Record<string, unknown>;
+    const name = typeof e.name === "string" ? e.name : null;
+    if (!name) continue;
+    const fields = parseFields(e.fields) ?? undefined;
+    const defaultField =
+      typeof e.default_field === "string" ? e.default_field : undefined;
+    out.push({ name, fields, defaultField });
+  }
+  return out;
+}
+
+/**
+ * Apply a named profile to the loaded config. The profile's `fields` and
+ * `default_field` (when present) replace the top-level values; everything
+ * else (triggers, profile list) is preserved.
+ */
+export function applyProfile(config: Config, profileName: string): Config {
+  const profile = config.profiles.find((p) => p.name === profileName);
+  if (!profile) {
+    const known = config.profiles.map((p) => p.name).join(", ") || "(none)";
+    throw new ConfigError(`unknown profile "${profileName}" (defined: ${known})`);
+  }
+  return {
+    ...config,
+    fields: profile.fields ?? config.fields,
+    defaultField: profile.defaultField ?? config.defaultField,
+  };
 }
 
 function parseTriggers(value: unknown): TriggerConfig[] {
@@ -155,6 +198,20 @@ const TEMPLATE = `// log-viewer config (JSON5: comments, trailing commas, unquot
     //   on_new_value: "podname",
     //   action: "say new pod {value} deployed",
     //   startup_delay_ms: 2000,
+    // },
+  ],
+
+  // Profiles override \`fields\` (and optionally \`default_field\`) when selected
+  // via \`--profile <name>\`. Useful for switching between different log
+  // shapes — e.g. one for app logs, one for kubectl/stern.
+  profiles: [
+    // {
+    //   name: "stern",
+    //   fields: [
+    //     { name: "time", from: ["timestamp"] },
+    //     { name: "pod",  from: ["podName"] },
+    //     { name: "msg",  from: ["message"] },
+    //   ],
     // },
   ],
 }

--- a/log-viewer/src/entry.ts
+++ b/log-viewer/src/entry.ts
@@ -47,11 +47,23 @@ export function renderField(entry: LogEntry, field: FieldConfig): string {
   return "";
 }
 
-function stringify(value: unknown): string {
+export function stringify(value: unknown): string {
   if (typeof value === "string") return value;
   if (typeof value === "number" || typeof value === "boolean") return String(value);
   try {
     return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}
+
+/** Render a value as a multi-line string suitable for the field detail view. */
+export function renderValueDetailed(value: unknown): string {
+  if (value === null || value === undefined) return "";
+  if (typeof value === "string") return value;
+  if (typeof value === "number" || typeof value === "boolean") return String(value);
+  try {
+    return JSON.stringify(value, null, 2);
   } catch {
     return String(value);
   }

--- a/log-viewer/src/index.ts
+++ b/log-viewer/src/index.ts
@@ -2,7 +2,7 @@
 import { existsSync } from "fs";
 import { spawnSync } from "child_process";
 import { cli, define } from "gunshi";
-import { configPath, ensureConfigFile, loadConfig } from "./config.js";
+import { applyProfile, configPath, ensureConfigFile, loadConfig } from "./config.js";
 import { startSource, type SourceSpec } from "./source.js";
 import { createTriggerRuntime } from "./triggers.js";
 import { runTui } from "./tui/index.js";
@@ -28,6 +28,10 @@ const main = define({
       type: "string",
       short: "c",
       description: "path to config file (overrides ~/.skagedal-tools/log-viewer/config.json5 and $LOG_VIEWER_CONFIG)",
+    },
+    profile: {
+      type: "string",
+      description: "name of a profile defined in the config file; overrides default fields/default_field",
     },
     exec: {
       type: "string",
@@ -63,6 +67,7 @@ const main = define({
     const values = ctx.values as {
       file?: string;
       config?: string;
+      profile?: string;
       browser: boolean;
       port: number;
       host: string;
@@ -102,7 +107,14 @@ const main = define({
     if (values.config && !existsSync(values.config)) {
       fail(`config file not found: ${values.config}`, 2);
     }
-    const config = loadConfig(values.config ?? configPath());
+    let config = loadConfig(values.config ?? configPath());
+    if (values.profile) {
+      try {
+        config = applyProfile(config, values.profile);
+      } catch (err) {
+        fail(err instanceof Error ? err.message : String(err), 2);
+      }
+    }
     const source = startSource(spec, { defaultField: config.defaultField });
 
     if (config.triggers.length > 0) {

--- a/log-viewer/src/tui/app.tsx
+++ b/log-viewer/src/tui/app.tsx
@@ -3,7 +3,7 @@ import { Box, Text, useApp, useInput, useStdout } from "ink";
 import clipboard from "clipboardy";
 import type { Config, FieldConfig } from "../config.js";
 import type { LogEntry } from "../entry.js";
-import { renderColumns, renderField } from "../entry.js";
+import { renderField, renderValueDetailed, stringify } from "../entry.js";
 import type { SourceHandle } from "../source.js";
 
 interface Props {
@@ -12,19 +12,38 @@ interface Props {
   sourceLabel: string;
 }
 
+/**
+ * A column definition the user can toggle at runtime. Pre-configured fields
+ * keep their friendly `name`/`from` mapping; raw keys discovered later become
+ * single-key entries with `name === from[0]`.
+ */
+interface ManagedField {
+  name: string;
+  from: string[];
+  visible: boolean;
+}
+
+type View = "list" | "detail" | "fieldsMenu";
+
 export const App: React.FC<Props> = ({ config, source, sourceLabel }) => {
   const { exit } = useApp();
   const { stdout } = useStdout();
   const [entries, setEntries] = useState<LogEntry[]>([]);
   const [cursor, setCursor] = useState(0);
-  const [view, setView] = useState<"list" | "detail">("list");
+  const [view, setView] = useState<View>("list");
   const [done, setDone] = useState(false);
   const [flash, setFlash] = useState<string | null>(null);
   const [follow, setFollow] = useState(false);
+  const [detailCursor, setDetailCursor] = useState(0);
+  const [menuCursor, setMenuCursor] = useState(0);
+  const [fields, setFields] = useState<ManagedField[]>(() =>
+    config.fields.map((f) => ({ name: f.name, from: [...f.from], visible: true })),
+  );
 
   useEffect(() => {
     source.onEntry((entry) => {
       setEntries((prev) => [...prev, entry]);
+      setFields((prev) => mergeSeenKeys(prev, Object.keys(entry.data)));
     });
     source.onEnd(() => setDone(true));
     return () => source.close();
@@ -40,40 +59,97 @@ export const App: React.FC<Props> = ({ config, source, sourceLabel }) => {
     }
   }, [entries.length, cursor, follow]);
 
-  // Reserve rows for the header (2), the status footer (1), and a margin (1).
+  // Reset detail-row cursor whenever we change entries or change view, so the
+  // cursor doesn't carry over from a previous entry's field count.
+  useEffect(() => {
+    setDetailCursor(0);
+  }, [view, cursor]);
+
   const totalRows = stdout?.rows ?? 24;
   const visible = Math.max(1, totalRows - 4);
+  const activeFields = useMemo(() => visibleFieldConfigs(fields), [fields]);
 
   useInput((input, key) => {
+    if (view === "fieldsMenu") {
+      if (input === "q" || key.escape || input === "v") {
+        setView("list");
+        return;
+      }
+      if (input === "j" || key.downArrow) {
+        setMenuCursor((c) => Math.min(fields.length - 1, c + 1));
+        return;
+      }
+      if (input === "k" || key.upArrow) {
+        setMenuCursor((c) => Math.max(0, c - 1));
+        return;
+      }
+      if (input === " " || input === "t") {
+        setFields((prev) => toggleAt(prev, menuCursor));
+        return;
+      }
+      if (input === "J") {
+        setFields((prev) => moveAt(prev, menuCursor, +1));
+        setMenuCursor((c) => Math.min(fields.length - 1, c + 1));
+        return;
+      }
+      if (input === "K") {
+        setFields((prev) => moveAt(prev, menuCursor, -1));
+        setMenuCursor((c) => Math.max(0, c - 1));
+        return;
+      }
+      return;
+    }
+
     if (view === "detail") {
       if (input === "q" || key.escape || input === "u") {
         setView("list");
         return;
       }
+      const entry = entries[cursor];
+      const keys = entry ? Object.keys(entry.data) : [];
+      // detailCursor 0 = entry header (whole entry); 1..keys.length = fields
       if (input === "j" || key.downArrow) {
-        setCursor((c) => Math.min(entries.length - 1, c + 1));
+        setDetailCursor((c) => Math.min(keys.length, c + 1));
         return;
       }
       if (input === "k" || key.upArrow) {
-        setCursor((c) => Math.max(0, c - 1));
+        setDetailCursor((c) => Math.max(0, c - 1));
+        return;
+      }
+      if (input === "v") {
+        setView("fieldsMenu");
+        return;
+      }
+      if (input === "t") {
+        if (detailCursor === 0 || !entry) return;
+        const key = keys[detailCursor - 1]!;
+        setFields((prev) => toggleByKey(prev, key));
+        const newState = toggleByKey(fields, key);
+        const fc = newState.find((f) => f.from[0] === key || f.from.includes(key));
+        flashFor(setFlash, `${fc?.visible ? "showing" : "hiding"} "${fc?.name ?? key}"`);
         return;
       }
       if (input === "c") {
-        const entry = entries[cursor];
         if (!entry) return;
-        const text = safeJson(entry.data);
-        try {
-          clipboard.writeSync(text);
-          flashFor(setFlash, `copied entry #${entry.id} (${text.length} bytes)`);
-        } catch (err) {
-          flashFor(setFlash, `copy failed: ${err instanceof Error ? err.message : String(err)}`);
+        if (detailCursor === 0) {
+          copyToClipboard(safeJson(entry.data), `entry #${entry.id} JSON`, setFlash);
+        } else {
+          const key = keys[detailCursor - 1]!;
+          const value = stringify(entry.data[key]);
+          copyToClipboard(value, `${key}`, setFlash);
         }
         return;
       }
       return;
     }
+
     if (input === "q" || key.escape) {
       exit();
+      return;
+    }
+    if (input === "v") {
+      setMenuCursor(0);
+      setView("fieldsMenu");
       return;
     }
     if (input === "f") {
@@ -114,14 +190,22 @@ export const App: React.FC<Props> = ({ config, source, sourceLabel }) => {
     }
   });
 
-  // Recompute when entries arrive — but only depend on length, not entries
-  // identity, so cursor/follow toggles don't reflow the layout.
   const widths = useMemo(
-    () => columnWidths(config, entries, stdout?.columns ?? 100),
-    [config, entries.length, stdout?.columns],
+    () => columnWidths(activeFields, entries, stdout?.columns ?? 100),
+    [activeFields, entries.length, stdout?.columns],
   );
   const start = Math.max(0, Math.min(cursor - Math.floor(visible / 2), entries.length - visible));
   const window = entries.slice(start, start + visible);
+
+  if (view === "fieldsMenu") {
+    return (
+      <FieldsMenu
+        fields={fields}
+        cursor={menuCursor}
+        flash={flash}
+      />
+    );
+  }
 
   if (view === "detail" && entries[cursor]) {
     return (
@@ -129,7 +213,10 @@ export const App: React.FC<Props> = ({ config, source, sourceLabel }) => {
         entry={entries[cursor]}
         sourceLabel={sourceLabel}
         position={{ index: cursor, total: entries.length }}
+        fields={fields}
+        cursor={detailCursor}
         flash={flash}
+        width={stdout?.columns ?? 100}
       />
     );
   }
@@ -137,7 +224,7 @@ export const App: React.FC<Props> = ({ config, source, sourceLabel }) => {
   return (
     <Box flexDirection="column" height={totalRows} width={stdout?.columns}>
       <Header
-        config={config}
+        fields={activeFields}
         widths={widths}
         sourceLabel={sourceLabel}
         count={entries.length}
@@ -155,7 +242,7 @@ export const App: React.FC<Props> = ({ config, source, sourceLabel }) => {
               <Row
                 key={entry.id}
                 entry={entry}
-                config={config}
+                fields={activeFields}
                 widths={widths}
                 selected={selected}
                 tail={tail}
@@ -171,13 +258,13 @@ export const App: React.FC<Props> = ({ config, source, sourceLabel }) => {
             <Text dimColor>
               {" "}
               {entries.length === 0 ? 0 : cursor + 1}/{entries.length} · any nav key exits · j/k
-              move · u up · o open · g/G top/bottom · q quit
+              move · u up · o open · v fields · g/G top/bottom · q quit
             </Text>
           </Text>
         ) : (
           <Text dimColor>
             {entries.length === 0 ? 0 : cursor + 1}/{entries.length} · j/k move · u up · o open · f
-            follow · g/G top/bottom · q quit
+            follow · v fields · g/G top/bottom · q quit
           </Text>
         )}
       </Box>
@@ -186,12 +273,12 @@ export const App: React.FC<Props> = ({ config, source, sourceLabel }) => {
 };
 
 const Header: React.FC<{
-  config: Config;
+  fields: FieldConfig[];
   widths: number[];
   sourceLabel: string;
   count: number;
   done: boolean;
-}> = ({ config, widths, sourceLabel, count, done }) => (
+}> = ({ fields, widths, sourceLabel, count, done }) => (
   <Box flexDirection="column">
     <Text>
       <Text bold>log-viewer</Text>
@@ -200,7 +287,8 @@ const Header: React.FC<{
       </Text>
     </Text>
     <Box>
-      {config.fields.map((field, i) => (
+      <Text> </Text>
+      {fields.map((field, i) => (
         <Box key={field.name} width={widths[i]} marginRight={1}>
           <Text bold underline>{truncate(field.name, widths[i] - 1)}</Text>
         </Box>
@@ -211,21 +299,21 @@ const Header: React.FC<{
 
 const Row: React.FC<{
   entry: LogEntry;
-  config: Config;
+  fields: FieldConfig[];
   widths: number[];
   selected: boolean;
   tail: boolean;
-}> = ({ entry, config, widths, selected, tail }) => {
-  const cols = renderColumns(entry, config);
-  const levelValue = cols.find((c) => c.name.toLowerCase() === "level")?.value ?? "";
+}> = ({ entry, fields, widths, selected, tail }) => {
+  const levelField = fields.find((f) => f.name.toLowerCase() === "level");
+  const levelValue = levelField ? renderField(entry, levelField) : "";
   const color = selected ? undefined : levelColor(levelValue);
   return (
     <Box>
       <Text color={tail ? "green" : undefined}>{tail ? "▌" : " "}</Text>
-      {cols.map((col, i) => (
-        <Box key={col.name} width={widths[i]} marginRight={1}>
+      {fields.map((field, i) => (
+        <Box key={field.name} width={widths[i]} marginRight={1}>
           <Text inverse={selected} color={color}>
-            {truncate(col.value, Math.max(1, widths[i] - 1))}
+            {truncate(renderField(entry, field), Math.max(1, widths[i] - 1))}
           </Text>
         </Box>
       ))}
@@ -237,33 +325,185 @@ const Detail: React.FC<{
   entry: LogEntry;
   sourceLabel: string;
   position: { index: number; total: number };
+  fields: ManagedField[];
+  cursor: number;
   flash: string | null;
-}> = ({ entry, sourceLabel, position, flash }) => {
-  const pretty = safeJson(entry.data);
+  width: number;
+}> = ({ entry, sourceLabel, position, fields, cursor, flash, width }) => {
+  const keys = Object.keys(entry.data);
+  const headerSelected = cursor === 0;
+  const keyColumnWidth = Math.max(
+    8,
+    Math.min(24, keys.reduce((w, k) => Math.max(w, k.length), 0) + 1),
+  );
   return (
     <Box flexDirection="column">
-      <Text>
+      <Text inverse={headerSelected}>
         <Text bold>entry #{entry.id}</Text>
-        <Text dimColor>
+        <Text dimColor={!headerSelected}>
           {" "}
           · {position.index + 1}/{position.total} · {sourceLabel}
           {entry.wrapped ? " · wrapped" : ""}
         </Text>
       </Text>
       <Box marginTop={1} flexDirection="column">
-        {pretty.split("\n").map((line, i) => (
-          <Text key={i}>{line}</Text>
-        ))}
+        {keys.length === 0 ? (
+          <Text dimColor>(empty)</Text>
+        ) : (
+          keys.map((key, i) => {
+            const selected = cursor === i + 1;
+            const visible = isKeyVisible(fields, key);
+            return (
+              <FieldRow
+                key={key}
+                fieldName={key}
+                value={entry.data[key]}
+                visible={visible}
+                selected={selected}
+                keyColumnWidth={keyColumnWidth}
+                width={width}
+              />
+            );
+          })
+        )}
       </Box>
       <Box marginTop={1}>
         <Text dimColor>
-          j/k next/prev · c copy json · u/esc back · q back
+          j/k field · u/esc back · t toggle visibility · c copy · v fields menu
           {flash ? `  ·  ${flash}` : ""}
         </Text>
       </Box>
     </Box>
   );
 };
+
+const FieldRow: React.FC<{
+  fieldName: string;
+  value: unknown;
+  visible: boolean;
+  selected: boolean;
+  keyColumnWidth: number;
+  width: number;
+}> = ({ fieldName, value, visible, selected, keyColumnWidth, width }) => {
+  const rendered = renderValueDetailed(value);
+  const lines = rendered.split("\n");
+  const valueWidth = Math.max(10, width - keyColumnWidth - 4);
+  return (
+    <Box>
+      <Box width={2}><Text>{visible ? "•" : " "}</Text></Box>
+      <Box width={keyColumnWidth} marginRight={1}>
+        <Text inverse={selected} bold dimColor={!selected && !visible}>
+          {truncate(fieldName, keyColumnWidth - 1)}
+        </Text>
+      </Box>
+      <Box flexDirection="column">
+        {lines.map((line, i) => (
+          <Text key={i} inverse={selected} dimColor={!selected && !visible}>
+            {truncate(line, valueWidth)}
+          </Text>
+        ))}
+      </Box>
+    </Box>
+  );
+};
+
+const FieldsMenu: React.FC<{
+  fields: ManagedField[];
+  cursor: number;
+  flash: string | null;
+}> = ({ fields, cursor, flash }) => {
+  const nameWidth = Math.max(
+    8,
+    fields.reduce((w, f) => Math.max(w, f.name.length), 0) + 1,
+  );
+  return (
+    <Box flexDirection="column">
+      <Text>
+        <Text bold>Fields</Text>
+        <Text dimColor> · select which columns appear and in what order</Text>
+      </Text>
+      <Box marginTop={1} flexDirection="column">
+        {fields.length === 0 ? (
+          <Text dimColor>(no fields seen yet)</Text>
+        ) : (
+          fields.map((f, i) => {
+            const selected = i === cursor;
+            const mark = f.visible ? "[x]" : "[ ]";
+            const fromHint = f.from.length > 1 || f.from[0] !== f.name
+              ? ` (from: ${f.from.join(", ")})`
+              : "";
+            return (
+              <Text key={f.name} inverse={selected} dimColor={!selected && !f.visible}>
+                {" "}{mark} {pad(f.name, nameWidth)}{fromHint}
+              </Text>
+            );
+          })
+        )}
+      </Box>
+      <Box marginTop={1}>
+        <Text dimColor>
+          j/k move · space/t toggle · J/K reorder · v/q/esc back
+          {flash ? `  ·  ${flash}` : ""}
+        </Text>
+      </Box>
+    </Box>
+  );
+};
+
+function visibleFieldConfigs(fields: ManagedField[]): FieldConfig[] {
+  return fields.filter((f) => f.visible).map((f) => ({ name: f.name, from: f.from }));
+}
+
+function mergeSeenKeys(prev: ManagedField[], keys: string[]): ManagedField[] {
+  const knownFroms = new Set<string>();
+  for (const f of prev) for (const k of f.from) knownFroms.add(k);
+  let next: ManagedField[] | null = null;
+  for (const key of keys) {
+    if (knownFroms.has(key)) continue;
+    knownFroms.add(key);
+    if (!next) next = [...prev];
+    next.push({ name: key, from: [key], visible: false });
+  }
+  return next ?? prev;
+}
+
+function toggleAt(fields: ManagedField[], index: number): ManagedField[] {
+  if (index < 0 || index >= fields.length) return fields;
+  return fields.map((f, i) => (i === index ? { ...f, visible: !f.visible } : f));
+}
+
+function moveAt(fields: ManagedField[], index: number, delta: number): ManagedField[] {
+  const target = index + delta;
+  if (index < 0 || index >= fields.length || target < 0 || target >= fields.length) {
+    return fields;
+  }
+  const next = [...fields];
+  const [item] = next.splice(index, 1);
+  next.splice(target, 0, item!);
+  return next;
+}
+
+function toggleByKey(fields: ManagedField[], key: string): ManagedField[] {
+  const idx = fields.findIndex((f) => f.from.includes(key));
+  if (idx === -1) {
+    return [...fields, { name: key, from: [key], visible: true }];
+  }
+  return toggleAt(fields, idx);
+}
+
+function isKeyVisible(fields: ManagedField[], key: string): boolean {
+  const f = fields.find((f) => f.from.includes(key));
+  return f ? f.visible : false;
+}
+
+function copyToClipboard(text: string, label: string, setFlash: (v: string | null) => void): void {
+  try {
+    clipboard.writeSync(text);
+    flashFor(setFlash, `copied ${label} (${text.length} bytes)`);
+  } catch (err) {
+    flashFor(setFlash, `copy failed: ${err instanceof Error ? err.message : String(err)}`);
+  }
+}
 
 function safeJson(data: unknown): string {
   try {
@@ -282,15 +522,17 @@ function flashFor(
   setTimeout(() => setFlash(null), ms);
 }
 
-function columnWidths(config: Config, entries: LogEntry[], totalColumns: number): number[] {
-  const n = config.fields.length;
+function columnWidths(
+  fields: FieldConfig[],
+  entries: LogEntry[],
+  totalColumns: number,
+): number[] {
+  const n = fields.length;
   if (n === 0) return [];
-  // Each non-last column shrinks/grows to fit its widest rendered value (and
-  // its header), capped so one huge field can't crowd out the last column.
   const cap = Math.max(20, Math.floor(totalColumns / 3));
   const widths: number[] = [];
   for (let i = 0; i < n - 1; i++) {
-    const field = config.fields[i]!;
+    const field = fields[i]!;
     let w = field.name.length;
     for (const entry of entries) {
       const v = renderField(entry, field);
@@ -300,10 +542,8 @@ function columnWidths(config: Config, entries: LogEntry[], totalColumns: number)
         break;
       }
     }
-    widths.push(w + 1); // padding so columns don't visually butt up against each other
+    widths.push(w + 1);
   }
-  // Last column absorbs whatever's left. The trailing `n` accounts for the
-  // 1-cell marginRight between columns plus the leading follow-mode marker.
   const fixed = widths.reduce((a, b) => a + b, 0);
   const last = Math.max(20, totalColumns - fixed - n);
   widths.push(last);
@@ -314,6 +554,11 @@ function truncate(value: string, width: number): string {
   const clean = value.replace(/\s+/g, " ");
   if (clean.length <= width) return clean;
   return clean.slice(0, Math.max(0, width - 1)) + "…";
+}
+
+function pad(value: string, width: number): string {
+  if (value.length >= width) return value;
+  return value + " ".repeat(width - value.length);
 }
 
 function levelColor(level: string): string | undefined {

--- a/log-viewer/src/tui/app.tsx
+++ b/log-viewer/src/tui/app.tsx
@@ -39,6 +39,19 @@ export const App: React.FC<Props> = ({ config, source, sourceLabel }) => {
   const [fields, setFields] = useState<ManagedField[]>(() =>
     config.fields.map((f) => ({ name: f.name, from: [...f.from], visible: true })),
   );
+  const [size, setSize] = useState<{ rows: number; cols: number }>(() => ({
+    rows: stdout?.rows ?? 24,
+    cols: stdout?.columns ?? 100,
+  }));
+
+  useEffect(() => {
+    if (!stdout) return;
+    const onResize = () => setSize({ rows: stdout.rows, cols: stdout.columns });
+    stdout.on("resize", onResize);
+    return () => {
+      stdout.off("resize", onResize);
+    };
+  }, [stdout]);
 
   useEffect(() => {
     source.onEntry((entry) => {
@@ -65,7 +78,7 @@ export const App: React.FC<Props> = ({ config, source, sourceLabel }) => {
     setDetailCursor(0);
   }, [view, cursor]);
 
-  const totalRows = stdout?.rows ?? 24;
+  const totalRows = size.rows;
   const visible = Math.max(1, totalRows - 4);
   const activeFields = useMemo(() => visibleFieldConfigs(fields), [fields]);
 
@@ -79,7 +92,7 @@ export const App: React.FC<Props> = ({ config, source, sourceLabel }) => {
         setMenuCursor((c) => Math.min(fields.length - 1, c + 1));
         return;
       }
-      if (input === "k" || key.upArrow) {
+      if (input === "k" || key.upArrow || input === "u") {
         setMenuCursor((c) => Math.max(0, c - 1));
         return;
       }
@@ -114,6 +127,14 @@ export const App: React.FC<Props> = ({ config, source, sourceLabel }) => {
       }
       if (input === "k" || key.upArrow) {
         setDetailCursor((c) => Math.max(0, c - 1));
+        return;
+      }
+      if (input === "n") {
+        setCursor((c) => Math.min(entries.length - 1, c + 1));
+        return;
+      }
+      if (input === "p") {
+        setCursor((c) => Math.max(0, c - 1));
         return;
       }
       if (input === "v") {
@@ -191,8 +212,8 @@ export const App: React.FC<Props> = ({ config, source, sourceLabel }) => {
   });
 
   const widths = useMemo(
-    () => columnWidths(activeFields, entries, stdout?.columns ?? 100),
-    [activeFields, entries.length, stdout?.columns],
+    () => columnWidths(activeFields, entries, size.cols),
+    [activeFields, entries.length, size.cols],
   );
   const start = Math.max(0, Math.min(cursor - Math.floor(visible / 2), entries.length - visible));
   const window = entries.slice(start, start + visible);
@@ -216,13 +237,13 @@ export const App: React.FC<Props> = ({ config, source, sourceLabel }) => {
         fields={fields}
         cursor={detailCursor}
         flash={flash}
-        width={stdout?.columns ?? 100}
+        width={size.cols}
       />
     );
   }
 
   return (
-    <Box flexDirection="column" height={totalRows} width={stdout?.columns}>
+    <Box flexDirection="column" height={totalRows} width={size.cols}>
       <Header
         fields={activeFields}
         widths={widths}
@@ -369,7 +390,7 @@ const Detail: React.FC<{
       </Box>
       <Box marginTop={1}>
         <Text dimColor>
-          j/k field · u/esc back · t toggle visibility · c copy · v fields menu
+          j/k field · n/p next/prev entry · u/esc back · t toggle visibility · c copy · v fields menu
           {flash ? `  ·  ${flash}` : ""}
         </Text>
       </Box>
@@ -442,7 +463,7 @@ const FieldsMenu: React.FC<{
       </Box>
       <Box marginTop={1}>
         <Text dimColor>
-          j/k move · space/t toggle · J/K reorder · v/q/esc back
+          j/k (or u) move · space/t toggle · J/K reorder · v/q/esc back
           {flash ? `  ·  ${flash}` : ""}
         </Text>
       </Box>

--- a/log-viewer/web/app.css
+++ b/log-viewer/web/app.css
@@ -9,6 +9,8 @@
   --warn: #ecc94b;
   --info: #63b3ed;
   --debug: #a0aec0;
+  --accent: #4299e1;
+  --panel: #15171c;
 }
 
 @media (prefers-color-scheme: light) {
@@ -22,6 +24,8 @@
     --warn: #b7791f;
     --info: #2b6cb0;
     --debug: #4a5568;
+    --accent: #2b6cb0;
+    --panel: #f7fafc;
   }
 }
 
@@ -48,20 +52,42 @@ header, footer {
   border-bottom: 1px solid var(--border);
   display: flex;
   gap: 12px;
-  align-items: baseline;
+  align-items: center;
 }
+
+header .header-spacer { flex: 1; }
 
 footer {
   border-bottom: none;
   border-top: 1px solid var(--border);
   justify-content: space-between;
   color: var(--dim);
+  align-items: baseline;
 }
 
 #meta { color: var(--dim); }
 .hint { color: var(--dim); }
 
-/* Scroll the body of the table, not the page; lets the header stay sticky. */
+button {
+  font: inherit;
+  background: transparent;
+  color: var(--fg);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 2px 8px;
+  cursor: pointer;
+}
+
+button:hover:not(:disabled) {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
+button:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
 #scroll {
   flex: 1;
   overflow: auto;
@@ -89,8 +115,6 @@ footer {
   z-index: 1;
 }
 
-/* Trick: width: 1% + nowrap makes a column shrink to its content. The
-   remaining column(s) without an explicit width absorb the rest. */
 #log-table .col-fit {
   width: 1%;
   white-space: nowrap;
@@ -104,19 +128,158 @@ footer {
   background: var(--selected);
 }
 
+#log-table tr {
+  cursor: pointer;
+}
+
 td.level-error { color: var(--error); }
 td.level-warn { color: var(--warn); }
 td.level-info { color: var(--info); }
 td.level-debug { color: var(--debug); }
 
-#detail {
-  position: fixed;
-  inset: 0;
-  background: var(--bg);
-  padding: 12px 16px;
-  overflow: auto;
-  border-left: 1px solid var(--border);
+#log-table tr.detail-row td {
+  background: var(--panel);
+  padding: 8px 12px;
+  cursor: default;
 }
 
-#detail h2 { margin: 0 0 8px; font-size: 14px; }
-#detail pre { white-space: pre-wrap; word-break: break-word; }
+.detail {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.detail-head {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 4px 6px;
+  border-radius: 4px;
+}
+
+.detail-head.detail-selected {
+  outline: 2px solid var(--accent);
+}
+
+.detail-head strong { font-size: 13px; }
+
+.detail-empty { color: var(--dim); }
+
+.detail-fields {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  margin: 0;
+  padding: 0;
+}
+
+.detail-field {
+  display: grid;
+  grid-template-columns: auto auto 1fr auto;
+  gap: 8px;
+  align-items: start;
+  padding: 4px 6px;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.detail-field:hover {
+  background: rgba(255, 255, 255, 0.04);
+}
+
+.detail-field.detail-selected {
+  outline: 2px solid var(--accent);
+}
+
+.detail-field.hidden-field {
+  opacity: 0.5;
+}
+
+.detail-field dt {
+  font-weight: 600;
+  color: var(--dim);
+  margin: 0;
+}
+
+.detail-field dd {
+  margin: 0;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.detail-field input[type="checkbox"] {
+  margin-top: 2px;
+}
+
+.popover {
+  position: fixed;
+  top: 44px;
+  right: 16px;
+  width: 360px;
+  max-height: 70vh;
+  overflow: auto;
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  box-shadow: 0 6px 24px rgba(0, 0, 0, 0.35);
+  padding: 10px 12px;
+  z-index: 10;
+}
+
+.popover-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 8px;
+}
+
+.popover-head button {
+  border: none;
+  font-size: 18px;
+  line-height: 1;
+  padding: 0 6px;
+}
+
+.popover ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.popover li {
+  display: grid;
+  grid-template-columns: auto auto 1fr auto auto;
+  gap: 6px;
+  align-items: center;
+  padding: 4px 6px;
+  border-radius: 4px;
+  border: 1px solid transparent;
+  cursor: grab;
+}
+
+.popover li.empty {
+  display: block;
+  color: var(--dim);
+  cursor: default;
+}
+
+.popover li.dragging { opacity: 0.5; }
+
+.popover li:hover { border-color: var(--border); }
+
+.popover li .drag-handle {
+  color: var(--dim);
+  user-select: none;
+}
+
+.popover li .field-name { font-weight: 600; }
+.popover li .field-from { color: var(--dim); font-size: 12px; }
+
+.popover-hint {
+  color: var(--dim);
+  font-size: 12px;
+  margin: 8px 0 0;
+}

--- a/log-viewer/web/app.css
+++ b/log-viewer/web/app.css
@@ -250,8 +250,9 @@ td.level-debug { color: var(--debug); }
 }
 
 .popover li {
+  position: relative;
   display: grid;
-  grid-template-columns: auto auto 1fr auto auto;
+  grid-template-columns: auto auto 1fr auto;
   gap: 6px;
   align-items: center;
   padding: 4px 6px;
@@ -266,14 +267,37 @@ td.level-debug { color: var(--debug); }
   cursor: default;
 }
 
-.popover li.dragging { opacity: 0.5; }
+.popover li.dragging {
+  opacity: 0.4;
+  cursor: grabbing;
+}
 
 .popover li:hover { border-color: var(--border); }
 
 .popover li .drag-handle {
   color: var(--dim);
+  font-size: 16px;
+  line-height: 1;
   user-select: none;
+  padding: 0 2px;
 }
+
+/* Drop indicators: a bright bar shows exactly where the dragged item will
+   land, above (drop-before) or below (drop-after) the target row. */
+.popover li.drop-before::before,
+.popover li.drop-after::after {
+  content: "";
+  position: absolute;
+  left: 4px;
+  right: 4px;
+  height: 2px;
+  background: var(--accent);
+  border-radius: 1px;
+  pointer-events: none;
+}
+
+.popover li.drop-before::before { top: -2px; }
+.popover li.drop-after::after { bottom: -2px; }
 
 .popover li .field-name { font-weight: 600; }
 .popover li .field-from { color: var(--dim); font-size: 12px; }

--- a/log-viewer/web/app.js
+++ b/log-viewer/web/app.js
@@ -1,37 +1,64 @@
 // Browser-side log viewer. Fetches config + entries via SSE and renders a
-// simple table with vi-like navigation (j/k/u/o, g/G, esc).
+// simple table with vi-like navigation (j/k/u/o, g/G, esc, v/t).
+//
+// State model:
+//   fields: ManagedField[] — every column we know about. visible == false
+//                            means it's not rendered as a table column but
+//                            still listed in the v menu.
+//   entries: LogEntry[]    — log entries in arrival order.
+//   cursor: number         — selected entry index in the list.
+//   expanded: Set<number>  — entry ids whose detail view is shown inline.
+//   detailCursor: number   — which row of the expanded detail is selected
+//                            (0 = the entry header itself, 1..n = fields).
 
 const headerRow = document.getElementById("header-row");
 const rowsEl = document.getElementById("rows");
 const statusEl = document.getElementById("status");
 const metaEl = document.getElementById("meta");
-const detailEl = document.getElementById("detail");
-const detailBody = document.getElementById("detail-body");
-const detailId = document.getElementById("detail-id");
+const fieldsBtn = document.getElementById("fields-btn");
+const fieldsPopover = document.getElementById("fields-popover");
+const fieldsList = document.getElementById("fields-list");
+const fieldsClose = document.getElementById("fields-close");
 
-let config = null;
+let sourceLabel = "";
+let fields = [];
 let entries = [];
 let cursor = 0;
-let view = "list";
+let expanded = new Set();
+let detailCursor = 0;
 let done = false;
 let follow = false;
 
 async function start() {
   const meta = await fetch("/api/meta").then((r) => r.json());
-  config = meta.config;
-  metaEl.textContent = `· ${meta.sourceLabel}`;
+  sourceLabel = meta.sourceLabel;
+  fields = (meta.config.fields ?? []).map((f) => ({
+    name: f.name,
+    from: [...f.from],
+    visible: true,
+  }));
+  metaEl.textContent = `· ${sourceLabel}`;
   renderHeader();
+  renderRows();
   startStream();
+  wireFieldsPopover();
 }
 
 function renderHeader() {
   headerRow.replaceChildren();
-  const last = config.fields.length - 1;
-  for (let i = 0; i < config.fields.length; i++) {
-    const field = config.fields[i];
+  const visible = fields.filter((f) => f.visible);
+  const last = visible.length - 1;
+  for (let i = 0; i < visible.length; i++) {
+    const field = visible[i];
     const th = document.createElement("th");
     th.textContent = field.name;
     th.classList.add(i === last ? "col-flex" : "col-fit");
+    headerRow.appendChild(th);
+  }
+  if (visible.length === 0) {
+    const th = document.createElement("th");
+    th.textContent = "(no visible fields — open the Fields menu)";
+    th.classList.add("col-flex");
     headerRow.appendChild(th);
   }
 }
@@ -41,8 +68,14 @@ function startStream() {
   es.addEventListener("entry", (ev) => {
     const entry = JSON.parse(ev.data);
     entries.push(entry);
-    appendRow(entry);
+    mergeSeenKeys(Object.keys(entry.data));
+    renderRows();
     updateStatus();
+    if (follow) {
+      setCursor(entries.length - 1, { keepFollow: true });
+    } else if (entries.length === 1) {
+      setCursor(0);
+    }
   });
   es.addEventListener("end", () => {
     done = true;
@@ -54,31 +87,156 @@ function startStream() {
   };
 }
 
-function appendRow(entry) {
-  const tr = document.createElement("tr");
-  tr.dataset.id = String(entry.id);
-  const last = config.fields.length - 1;
-  for (let i = 0; i < config.fields.length; i++) {
-    const field = config.fields[i];
-    const td = document.createElement("td");
-    const value = pickField(entry.data, field.from);
-    td.textContent = value;
-    td.classList.add(i === last ? "col-flex" : "col-fit");
-    if (field.name.toLowerCase() === "level") {
-      td.classList.add(`level-${classifyLevel(value)}`);
+function mergeSeenKeys(keys) {
+  const known = new Set();
+  for (const f of fields) for (const k of f.from) known.add(k);
+  let added = false;
+  for (const key of keys) {
+    if (known.has(key)) continue;
+    known.add(key);
+    fields.push({ name: key, from: [key], visible: false });
+    added = true;
+  }
+  if (added && !fieldsPopover.hidden) renderFieldsList();
+}
+
+function renderRows() {
+  rowsEl.replaceChildren();
+  const visible = fields.filter((f) => f.visible);
+  const colCount = Math.max(1, visible.length);
+  for (let i = 0; i < entries.length; i++) {
+    const entry = entries[i];
+    const tr = document.createElement("tr");
+    tr.dataset.id = String(entry.id);
+    if (i === cursor && !follow) tr.classList.add("selected");
+    const last = visible.length - 1;
+    for (let j = 0; j < visible.length; j++) {
+      const field = visible[j];
+      const td = document.createElement("td");
+      const value = pickField(entry.data, field.from);
+      td.textContent = value;
+      td.classList.add(j === last ? "col-flex" : "col-fit");
+      if (field.name.toLowerCase() === "level") {
+        td.classList.add(`level-${classifyLevel(value)}`);
+      }
+      tr.appendChild(td);
     }
-    tr.appendChild(td);
+    if (visible.length === 0) {
+      const td = document.createElement("td");
+      td.textContent = "—";
+      td.classList.add("col-flex");
+      tr.appendChild(td);
+    }
+    tr.addEventListener("click", () => {
+      setCursor(i);
+      toggleExpand(entry.id);
+    });
+    rowsEl.appendChild(tr);
+    if (expanded.has(entry.id)) {
+      rowsEl.appendChild(renderDetailRow(entry, colCount, i === cursor));
+    }
   }
-  tr.addEventListener("click", () => {
-    setCursor(entries.findIndex((e) => e.id === entry.id));
-    openDetail();
+  if (cursor >= 0 && cursor < entries.length) {
+    const sel = rowsEl.querySelector(`tr.selected`);
+    if (sel && follow === false) sel.scrollIntoView({ block: "nearest" });
+  }
+}
+
+function renderDetailRow(entry, colCount, parentSelected) {
+  const tr = document.createElement("tr");
+  tr.classList.add("detail-row");
+  const td = document.createElement("td");
+  td.colSpan = colCount;
+  td.appendChild(renderDetailContent(entry, parentSelected));
+  tr.appendChild(td);
+  return tr;
+}
+
+function renderDetailContent(entry, parentSelected) {
+  const wrap = document.createElement("div");
+  wrap.classList.add("detail");
+
+  const head = document.createElement("div");
+  head.classList.add("detail-head");
+  if (parentSelected && detailCursor === 0) head.classList.add("detail-selected");
+  const title = document.createElement("strong");
+  title.textContent = `entry #${entry.id}${entry.wrapped ? " (wrapped)" : ""}`;
+  head.appendChild(title);
+  const copyEntry = document.createElement("button");
+  copyEntry.type = "button";
+  copyEntry.textContent = "Copy JSON";
+  copyEntry.addEventListener("click", (ev) => {
+    ev.stopPropagation();
+    copyText(JSON.stringify(entry.data, null, 2), `entry #${entry.id}`);
   });
-  rowsEl.appendChild(tr);
-  if (follow) {
-    setCursor(entries.length - 1, { keepFollow: true });
-  } else if (entries.length === 1) {
-    setCursor(0);
+  head.appendChild(copyEntry);
+  head.addEventListener("click", () => {
+    if (parentSelected) {
+      detailCursor = 0;
+      renderRows();
+    }
+  });
+  wrap.appendChild(head);
+
+  const keys = Object.keys(entry.data);
+  if (keys.length === 0) {
+    const empty = document.createElement("div");
+    empty.classList.add("detail-empty");
+    empty.textContent = "(empty)";
+    wrap.appendChild(empty);
+    return wrap;
   }
+
+  const list = document.createElement("dl");
+  list.classList.add("detail-fields");
+  keys.forEach((key, idx) => {
+    const row = document.createElement("div");
+    row.classList.add("detail-field");
+    if (parentSelected && detailCursor === idx + 1) row.classList.add("detail-selected");
+    const visible = isKeyVisible(key);
+    if (!visible) row.classList.add("hidden-field");
+
+    const checkbox = document.createElement("input");
+    checkbox.type = "checkbox";
+    checkbox.checked = visible;
+    checkbox.title = visible ? "Hide this column" : "Show this column";
+    checkbox.addEventListener("click", (ev) => ev.stopPropagation());
+    checkbox.addEventListener("change", () => {
+      toggleByKey(key);
+      renderHeader();
+      renderRows();
+      if (!fieldsPopover.hidden) renderFieldsList();
+    });
+    row.appendChild(checkbox);
+
+    const dt = document.createElement("dt");
+    dt.textContent = key;
+    row.appendChild(dt);
+
+    const dd = document.createElement("dd");
+    dd.textContent = renderValueDetailed(entry.data[key]);
+    row.appendChild(dd);
+
+    const copyBtn = document.createElement("button");
+    copyBtn.type = "button";
+    copyBtn.textContent = "Copy";
+    copyBtn.addEventListener("click", (ev) => {
+      ev.stopPropagation();
+      copyText(stringifyValue(entry.data[key]), key);
+    });
+    row.appendChild(copyBtn);
+
+    row.addEventListener("click", () => {
+      if (parentSelected) {
+        detailCursor = idx + 1;
+        renderRows();
+      }
+    });
+
+    list.appendChild(row);
+  });
+  wrap.appendChild(list);
+  return wrap;
 }
 
 function pickField(data, candidates) {
@@ -88,6 +246,27 @@ function pickField(data, candidates) {
     return typeof value === "string" ? value : JSON.stringify(value);
   }
   return "";
+}
+
+function stringifyValue(value) {
+  if (typeof value === "string") return value;
+  if (typeof value === "number" || typeof value === "boolean") return String(value);
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}
+
+function renderValueDetailed(value) {
+  if (value === null || value === undefined) return "";
+  if (typeof value === "string") return value;
+  if (typeof value === "number" || typeof value === "boolean") return String(value);
+  try {
+    return JSON.stringify(value, null, 2);
+  } catch {
+    return String(value);
+  }
 }
 
 function classifyLevel(level) {
@@ -101,31 +280,26 @@ function classifyLevel(level) {
 
 function setCursor(i, opts = {}) {
   if (entries.length === 0) return;
-  if (!opts.keepFollow && follow) {
-    follow = false;
-  }
+  if (!opts.keepFollow && follow) follow = false;
   cursor = Math.max(0, Math.min(entries.length - 1, i));
-  applySelection();
-  const sel = rowsEl.children[cursor];
-  if (sel) sel.scrollIntoView({ block: "nearest" });
+  detailCursor = 0;
+  renderRows();
   updateStatus();
 }
 
-function applySelection() {
-  for (const el of rowsEl.querySelectorAll("tr.selected")) el.classList.remove("selected");
-  if (follow) return;
-  const sel = rowsEl.children[cursor];
-  if (sel) sel.classList.add("selected");
+function toggleExpand(id) {
+  if (expanded.has(id)) expanded.delete(id);
+  else expanded.add(id);
+  detailCursor = 0;
+  renderRows();
 }
 
 function toggleFollow() {
   follow = !follow;
   if (follow && entries.length > 0) {
     cursor = entries.length - 1;
-    const sel = rowsEl.children[cursor];
-    if (sel) sel.scrollIntoView({ block: "nearest" });
   }
-  applySelection();
+  renderRows();
   updateStatus();
 }
 
@@ -136,49 +310,223 @@ function updateStatus() {
   statusEl.textContent = `${pos}/${entries.length}${eof}${tag}`;
 }
 
-function openDetail() {
-  const entry = entries[cursor];
-  if (!entry) return;
-  view = "detail";
-  detailId.textContent = `#${entry.id}${entry.wrapped ? " (wrapped)" : ""}`;
-  detailBody.textContent = JSON.stringify(entry.data, null, 2);
-  detailEl.hidden = false;
+function isKeyVisible(key) {
+  const f = fields.find((f) => f.from.includes(key));
+  return f ? f.visible : false;
 }
 
-function closeDetail() {
-  view = "list";
-  detailEl.hidden = true;
+function toggleByKey(key) {
+  const idx = fields.findIndex((f) => f.from.includes(key));
+  if (idx === -1) {
+    fields.push({ name: key, from: [key], visible: true });
+  } else {
+    fields[idx] = { ...fields[idx], visible: !fields[idx].visible };
+  }
+}
+
+function copyText(text, label) {
+  if (navigator.clipboard?.writeText) {
+    navigator.clipboard.writeText(text).then(
+      () => flashStatus(`copied ${label}`),
+      () => flashStatus(`copy failed`),
+    );
+  } else {
+    flashStatus("clipboard unavailable");
+  }
+}
+
+let flashTimer = null;
+function flashStatus(msg) {
+  const original = statusEl.textContent;
+  statusEl.textContent = `${original} · ${msg}`;
+  if (flashTimer) clearTimeout(flashTimer);
+  flashTimer = setTimeout(() => updateStatus(), 1500);
+}
+
+function wireFieldsPopover() {
+  fieldsBtn.addEventListener("click", () => {
+    if (fieldsPopover.hidden) openFields();
+    else closeFields();
+  });
+  fieldsClose.addEventListener("click", closeFields);
+  document.addEventListener("click", (ev) => {
+    if (fieldsPopover.hidden) return;
+    if (fieldsPopover.contains(ev.target) || fieldsBtn.contains(ev.target)) return;
+    closeFields();
+  });
+}
+
+function openFields() {
+  fieldsPopover.hidden = false;
+  fieldsBtn.setAttribute("aria-expanded", "true");
+  renderFieldsList();
+}
+
+function closeFields() {
+  fieldsPopover.hidden = true;
+  fieldsBtn.setAttribute("aria-expanded", "false");
+}
+
+function renderFieldsList() {
+  fieldsList.replaceChildren();
+  fields.forEach((field, i) => {
+    const li = document.createElement("li");
+    li.draggable = true;
+    li.dataset.index = String(i);
+
+    const handle = document.createElement("span");
+    handle.className = "drag-handle";
+    handle.textContent = "≡";
+    li.appendChild(handle);
+
+    const checkbox = document.createElement("input");
+    checkbox.type = "checkbox";
+    checkbox.checked = field.visible;
+    checkbox.addEventListener("change", () => {
+      fields[i] = { ...fields[i], visible: checkbox.checked };
+      renderHeader();
+      renderRows();
+      renderFieldsList();
+    });
+    li.appendChild(checkbox);
+
+    const label = document.createElement("span");
+    label.className = "field-name";
+    label.textContent = field.name;
+    li.appendChild(label);
+
+    if (field.from.length > 1 || field.from[0] !== field.name) {
+      const hint = document.createElement("span");
+      hint.className = "field-from";
+      hint.textContent = `(from: ${field.from.join(", ")})`;
+      li.appendChild(hint);
+    }
+
+    const up = document.createElement("button");
+    up.type = "button";
+    up.textContent = "↑";
+    up.title = "Move up";
+    up.disabled = i === 0;
+    up.addEventListener("click", () => moveField(i, -1));
+    li.appendChild(up);
+
+    const down = document.createElement("button");
+    down.type = "button";
+    down.textContent = "↓";
+    down.title = "Move down";
+    down.disabled = i === fields.length - 1;
+    down.addEventListener("click", () => moveField(i, +1));
+    li.appendChild(down);
+
+    li.addEventListener("dragstart", (ev) => {
+      ev.dataTransfer.effectAllowed = "move";
+      ev.dataTransfer.setData("text/plain", String(i));
+      li.classList.add("dragging");
+    });
+    li.addEventListener("dragend", () => li.classList.remove("dragging"));
+    li.addEventListener("dragover", (ev) => {
+      ev.preventDefault();
+      ev.dataTransfer.dropEffect = "move";
+    });
+    li.addEventListener("drop", (ev) => {
+      ev.preventDefault();
+      const from = Number(ev.dataTransfer.getData("text/plain"));
+      const to = i;
+      if (Number.isFinite(from) && from !== to) reorderField(from, to);
+    });
+
+    fieldsList.appendChild(li);
+  });
+  if (fields.length === 0) {
+    const empty = document.createElement("li");
+    empty.className = "empty";
+    empty.textContent = "(no fields seen yet)";
+    fieldsList.appendChild(empty);
+  }
+}
+
+function moveField(index, delta) {
+  const target = index + delta;
+  if (target < 0 || target >= fields.length) return;
+  const [item] = fields.splice(index, 1);
+  fields.splice(target, 0, item);
+  renderHeader();
+  renderRows();
+  renderFieldsList();
+}
+
+function reorderField(from, to) {
+  const [item] = fields.splice(from, 1);
+  fields.splice(to, 0, item);
+  renderHeader();
+  renderRows();
+  renderFieldsList();
 }
 
 document.addEventListener("keydown", (ev) => {
   if (ev.metaKey || ev.ctrlKey || ev.altKey) return;
-  if (view === "detail") {
-    if (ev.key === "Escape" || ev.key === "u" || ev.key === "q") {
-      closeDetail();
+  const target = ev.target;
+  if (target && (target.tagName === "INPUT" || target.tagName === "BUTTON")) {
+    if (ev.key === "Escape") (target).blur?.();
+    return;
+  }
+  if (!fieldsPopover.hidden) {
+    if (ev.key === "Escape" || ev.key === "v" || ev.key === "q") {
+      closeFields();
       ev.preventDefault();
     }
     return;
   }
+  const entry = entries[cursor];
+  const isExpanded = entry && expanded.has(entry.id);
   switch (ev.key) {
     case "j":
     case "ArrowDown":
+      if (isExpanded) {
+        const keys = Object.keys(entry.data);
+        if (detailCursor < keys.length) {
+          detailCursor += 1;
+          renderRows();
+          ev.preventDefault();
+          return;
+        }
+      }
       setCursor(cursor + 1);
       ev.preventDefault();
       break;
     case "k":
     case "ArrowUp":
+      if (isExpanded && detailCursor > 0) {
+        detailCursor -= 1;
+        renderRows();
+        ev.preventDefault();
+        return;
+      }
       setCursor(cursor - 1);
       ev.preventDefault();
       break;
     case "u":
+      if (isExpanded) {
+        toggleExpand(entry.id);
+        ev.preventDefault();
+        return;
+      }
       setCursor(cursor - 1);
       ev.preventDefault();
       break;
     case "o":
     case "Enter":
-      if (follow) follow = false;
-      openDetail();
+      if (entry) {
+        if (follow) follow = false;
+        toggleExpand(entry.id);
+      }
       ev.preventDefault();
+      break;
+    case "Escape":
+      if (isExpanded) {
+        toggleExpand(entry.id);
+        ev.preventDefault();
+      }
       break;
     case "g":
       setCursor(0);
@@ -192,6 +540,35 @@ document.addEventListener("keydown", (ev) => {
       toggleFollow();
       ev.preventDefault();
       break;
+    case "v":
+      openFields();
+      ev.preventDefault();
+      break;
+    case "t": {
+      if (!isExpanded || !entry) return;
+      const keys = Object.keys(entry.data);
+      if (detailCursor === 0) return;
+      const key = keys[detailCursor - 1];
+      if (!key) return;
+      toggleByKey(key);
+      renderHeader();
+      renderRows();
+      if (!fieldsPopover.hidden) renderFieldsList();
+      ev.preventDefault();
+      break;
+    }
+    case "c": {
+      if (!entry) return;
+      if (isExpanded && detailCursor > 0) {
+        const keys = Object.keys(entry.data);
+        const key = keys[detailCursor - 1];
+        if (key) copyText(stringifyValue(entry.data[key]), key);
+      } else {
+        copyText(JSON.stringify(entry.data, null, 2), `entry #${entry.id}`);
+      }
+      ev.preventDefault();
+      break;
+    }
   }
 });
 

--- a/log-viewer/web/app.js
+++ b/log-viewer/web/app.js
@@ -402,36 +402,39 @@ function renderFieldsList() {
       li.appendChild(hint);
     }
 
-    const up = document.createElement("button");
-    up.type = "button";
-    up.textContent = "↑";
-    up.title = "Move up";
-    up.disabled = i === 0;
-    up.addEventListener("click", () => moveField(i, -1));
-    li.appendChild(up);
-
-    const down = document.createElement("button");
-    down.type = "button";
-    down.textContent = "↓";
-    down.title = "Move down";
-    down.disabled = i === fields.length - 1;
-    down.addEventListener("click", () => moveField(i, +1));
-    li.appendChild(down);
-
     li.addEventListener("dragstart", (ev) => {
       ev.dataTransfer.effectAllowed = "move";
       ev.dataTransfer.setData("text/plain", String(i));
       li.classList.add("dragging");
     });
-    li.addEventListener("dragend", () => li.classList.remove("dragging"));
+    li.addEventListener("dragend", () => {
+      li.classList.remove("dragging");
+      clearDropIndicators();
+    });
     li.addEventListener("dragover", (ev) => {
       ev.preventDefault();
       ev.dataTransfer.dropEffect = "move";
+      const rect = li.getBoundingClientRect();
+      const before = ev.clientY < rect.top + rect.height / 2;
+      clearDropIndicators();
+      li.classList.add(before ? "drop-before" : "drop-after");
+    });
+    li.addEventListener("dragleave", (ev) => {
+      // Only clear if the pointer actually left this li (and not just moved
+      // onto a child element). relatedTarget being inside li means it's still
+      // hovering this li.
+      if (ev.relatedTarget && li.contains(ev.relatedTarget)) return;
+      li.classList.remove("drop-before", "drop-after");
     });
     li.addEventListener("drop", (ev) => {
       ev.preventDefault();
       const from = Number(ev.dataTransfer.getData("text/plain"));
-      const to = i;
+      const rect = li.getBoundingClientRect();
+      const before = ev.clientY < rect.top + rect.height / 2;
+      let to = i + (before ? 0 : 1);
+      // Account for removing `from` first when it's above the insertion point.
+      if (from < to) to -= 1;
+      clearDropIndicators();
       if (Number.isFinite(from) && from !== to) reorderField(from, to);
     });
 
@@ -445,14 +448,10 @@ function renderFieldsList() {
   }
 }
 
-function moveField(index, delta) {
-  const target = index + delta;
-  if (target < 0 || target >= fields.length) return;
-  const [item] = fields.splice(index, 1);
-  fields.splice(target, 0, item);
-  renderHeader();
-  renderRows();
-  renderFieldsList();
+function clearDropIndicators() {
+  for (const el of fieldsList.querySelectorAll(".drop-before, .drop-after")) {
+    el.classList.remove("drop-before", "drop-after");
+  }
 }
 
 function reorderField(from, to) {

--- a/log-viewer/web/index.html
+++ b/log-viewer/web/index.html
@@ -11,6 +11,10 @@
       <header>
         <strong>log-viewer</strong>
         <span id="meta"></span>
+        <span class="header-spacer"></span>
+        <button id="fields-btn" type="button" aria-haspopup="dialog" aria-expanded="false">
+          Fields
+        </button>
       </header>
       <div id="scroll">
         <table id="log-table">
@@ -20,14 +24,18 @@
           <tbody id="rows"></tbody>
         </table>
       </div>
-      <section id="detail" hidden>
-        <h2>Entry <span id="detail-id"></span></h2>
-        <pre id="detail-body"></pre>
-      </section>
       <footer>
         <span id="status"></span>
-        <span class="hint">j/k move · u up · o open · f follow · g/G top/bottom · esc close detail</span>
+        <span class="hint">j/k move · u up · o open · f follow · v fields · g/G top/bottom · esc close</span>
       </footer>
+      <div id="fields-popover" class="popover" hidden role="dialog" aria-label="Manage fields">
+        <div class="popover-head">
+          <strong>Fields</strong>
+          <button id="fields-close" type="button" aria-label="Close">×</button>
+        </div>
+        <ul id="fields-list"></ul>
+        <p class="popover-hint">Drag the handle to reorder. Toggle the checkbox to show or hide a column.</p>
+      </div>
     </div>
     <script type="module" src="/app.js"></script>
   </body>

--- a/log-viewer/web/index.html
+++ b/log-viewer/web/index.html
@@ -34,7 +34,7 @@
           <button id="fields-close" type="button" aria-label="Close">×</button>
         </div>
         <ul id="fields-list"></ul>
-        <p class="popover-hint">Drag the handle to reorder. Toggle the checkbox to show or hide a column.</p>
+        <p class="popover-hint">Drag a row to reorder it. The blue bar shows where it will land. Toggle the checkbox to show or hide a column.</p>
       </div>
     </div>
     <script type="module" src="/app.js"></script>


### PR DESCRIPTION
## Summary

This PR adds a comprehensive field management system and redesigns the detail view to be inline and navigable, rather than a full-screen modal. Users can now toggle field visibility, reorder columns, and navigate through individual fields in an expanded entry view.

## Key Changes

### Detail View Redesign
- **Inline expansion**: Entries now expand inline below the selected row instead of opening a full-screen modal, allowing context preservation
- **Field-by-field navigation**: Detail view now shows each field on its own row with `j`/`k` navigation between fields
- **Per-field actions**: Users can copy individual field values, toggle field visibility with `t`, or copy the entire entry JSON
- **Visual hierarchy**: Entry header and fields are separately selectable with outline highlighting

### Field Management System
- **Runtime field discovery**: New fields seen in log entries are automatically added to the field list (initially hidden)
- **Visibility toggling**: Fields can be shown/hidden via the detail view (`t` key), fields menu (`v` key), or inline checkboxes (browser)
- **Column reordering**: Fields can be reordered via `J`/`K` keys (TUI) or drag-and-drop (browser)
- **Persistent state**: Field visibility and order are maintained across navigation

### New UI Components
- **Fields menu** (`v` key): Dedicated menu for managing all known fields with visibility toggles and reordering controls
- **Browser popover**: Fields button in header opens a popover with checkboxes and drag-reorder support
- **Inline checkboxes**: Each field in the detail view has a checkbox to toggle visibility without leaving the view

### Configuration Enhancements
- **Profiles**: New `profiles` config section allows defining named field layouts (e.g., different layouts for app logs vs. kubectl logs)
- **Profile selection**: `--profile <name>` CLI flag to activate a profile at startup

### Navigation Updates
- `v` key: Open fields menu (list and browser)
- `t` key: Toggle visibility of selected field in detail view
- `c` key: Copy selected field value (or full JSON if on entry header)
- `Escape` in detail: Close expanded view
- Updated help text to reflect new capabilities

### Implementation Details
- State model clearly documented in browser app.js with `fields`, `entries`, `cursor`, `expanded`, and `detailCursor`
- `ManagedField` interface tracks field name, source paths, and visibility state
- Detail content rendered as grid layout with field name, value, visibility checkbox, and copy button
- Browser CSS updated with new color variables (`--accent`, `--panel`) and styles for detail rows, popovers, and field lists
- TUI refactored to use `activeFields` (filtered visible fields) for rendering while maintaining full field list in state

https://claude.ai/code/session_01E6oMs2tQkENZmJcV8KAZca