### PR TITLE
Add `raw` subcommand, `link --open`, region config, and terminal helpers

### DIFF
--- a/cloudwatch-insights/README.md
+++ b/cloudwatch-insights/README.md
@@ -21,6 +21,8 @@ This builds the TypeScript source and installs the `cloudwatch-insights` command
 
 ```
 cloudwatch-insights query [options]       run a query
+cloudwatch-insights raw [options]         run a query verbatim from a file (no templating, no config)
+cloudwatch-insights link [options]        print a shareable AWS Console URL
 cloudwatch-insights show                  stream the latest run to stdout
 cloudwatch-insights edit-config           edit the per-repo config
 ```
@@ -58,6 +60,28 @@ jq . < "$last"
 ```
 
 After every successful run the symlink `~/.skagedal-tools/cloudwatch-insights/latest-run.jsonl` is updated to point at the new file.
+
+### `raw`
+
+```sh
+cloudwatch-insights raw -f query.txt -g /aws/lambda/my-func -t 5h
+cloudwatch-insights raw -f query.txt -g /a -g /b -t "yesterday 17-18" -o results.jsonl
+cat query.txt | cloudwatch-insights raw -f - -g /my/group
+```
+
+Runs a query verbatim from `--query-file`/`-f` (use `-` for stdin). No front-matter parsing, no `{{ env }} / {{ app }}` substitution, no flatten-fields, no config lookup, no editor, no `latest-run.jsonl` symlink — the contents of the file are sent to CloudWatch as-is.
+
+Results are written to stdout as JSONL, or to `--output`/`-o` if given. Required: `--query-file` and at least one `--log-group`.
+
+### `link`
+
+```sh
+cloudwatch-insights link
+cloudwatch-insights link --open                  # also open in default browser
+cloudwatch-insights link --preserve-time-window
+```
+
+Prints a shareable AWS Console URL for the query that `cloudwatch-insights query` would otherwise run. When stdout is a TTY, the URL is also rendered as an [OSC 8 clickable hyperlink](https://gist.github.com/egmontkob/eb114294efbcd5adb1944c9f3cb5feda) above the raw URL — terminals that understand the escape sequence (iTerm2, recent VS Code, GNOME Terminal, WezTerm, …) make it click-to-open. Pass `--open` to additionally open the URL in your default browser.
 
 ### `show`
 
@@ -170,6 +194,7 @@ Fields legal in both `[defaults]` and `[repo.<name>]`:
 
 - `group` — log group used when no `--log-group` / front-matter `log-group` is given. `{{ env }}` and `{{ app }}` are expanded at query time.
 - `app` — used only when seeding a fresh `current.insights`: the seeded query body will filter on `app = "<app>"`.
+- `region` — AWS region fallback used when no `[env.<name>].region` applies (and `--region` / `AWS_REGION` aren't set).
 - `flatten-fields` — array of field names whose value is a JSON-encoded object. After each query, those fields are JSON-decoded and their keys merged into the row (the original field is removed). If a value isn't valid JSON or isn't a plain object, the field is left untouched. Useful for log-line fields like `@message` that wrap structured payloads.
 
 `[env.<name>]` declares an environment (any lower kebab-case name — e.g. `prod`, `systest`, `us-east-1`). Supported keys:
@@ -177,7 +202,7 @@ Fields legal in both `[defaults]` and `[repo.<name>]`:
 - `aws-profile` — exported as `AWS_PROFILE` for the run unless `--profile` overrides it.
 - `region` — passed to the AWS SDK unless `--region` / `AWS_REGION` overrides it.
 
-A repo can override individual keys via `[repo.<repo>.env.<env>]`. Inside an env block the merge is **per-key**: only the fields you mention are overridden; the rest fall through to the top-level entry. Resolution order at query time: `--profile` / `--region` > `[repo.X.env.Y]` > `[env.Y]` > `AWS_PROFILE` / `AWS_REGION` env vars > SDK default chain.
+A repo can override individual keys via `[repo.<repo>.env.<env>]`. Inside an env block the merge is **per-key**: only the fields you mention are overridden; the rest fall through to the top-level entry. Resolution order at query time: `--profile` / `--region` > `[repo.X.env.Y]` > `[env.Y]` > `[repo.X].region` / `[defaults].region` (region only) > `AWS_PROFILE` / `AWS_REGION` env vars > SDK default chain.
 
 Using `--environment <name>` for an env name that has no `[env.<name>]` section is fine — `{{ env }}` substitution still works; `aws-profile` and `region` simply aren't auto-set.
 

--- a/cloudwatch-insights/README.md
+++ b/cloudwatch-insights/README.md
@@ -23,6 +23,7 @@ This builds the TypeScript source and installs the `cloudwatch-insights` command
 cloudwatch-insights query [options]       run a query
 cloudwatch-insights raw [options]         run a query verbatim from a file (no templating, no config)
 cloudwatch-insights link [options]        print a shareable AWS Console URL
+cloudwatch-insights parse-link <url>      decode a Console URL into current.insights (or a `raw` command)
 cloudwatch-insights show                  stream the latest run to stdout
 cloudwatch-insights edit-config           edit the per-repo config
 ```
@@ -82,6 +83,20 @@ cloudwatch-insights link --preserve-time-window
 ```
 
 Prints a shareable AWS Console URL for the query that `cloudwatch-insights query` would otherwise run. When stdout is a TTY, the URL is also rendered as an [OSC 8 clickable hyperlink](https://gist.github.com/egmontkob/eb114294efbcd5adb1944c9f3cb5feda) above the raw URL — terminals that understand the escape sequence (iTerm2, recent VS Code, GNOME Terminal, WezTerm, …) make it click-to-open. Pass `--open` to additionally open the URL in your default browser.
+
+### `parse-link`
+
+```sh
+cloudwatch-insights parse-link 'https://eu-north-1.console.aws.amazon.com/cloudwatch/home?region=eu-north-1#logsV2:logs-insights$3FqueryDetail$3D~(...)'
+pbpaste | cloudwatch-insights parse-link                # read URL from stdin
+cloudwatch-insights parse-link --as-raw <url>           # print a `raw` shell command instead
+```
+
+The inverse of `link`. Decodes the AWS Console Insights URL and recreates the query state by writing a fresh `current.insights` for the current slot (with `time`, `log-group`, and the query body filled in from the URL) — running `cloudwatch-insights query` afterwards re-runs the same query.
+
+`--as-raw` instead prints a self-contained `cloudwatch-insights raw …` shell command (a quoted heredoc piping the query body into stdin) and does not touch any state. Useful for sharing a one-shot invocation that someone else can paste into a terminal.
+
+The URL can be passed as a positional argument, via `--url`, or piped on stdin. `-o`/`--output` writes the `.insights` file to a custom path instead of the current slot's `current.insights`.
 
 ### `show`
 

--- a/cloudwatch-insights/src/config.mts
+++ b/cloudwatch-insights/src/config.mts
@@ -25,6 +25,11 @@ export interface RepoConfig {
   /** Field names whose value is a JSON object to be flattened into the row. */
   flattenFields?: string[];
   /**
+   * Default AWS region for runs from this repo (or globally, when set in
+   * [defaults]). Used as a fallback when no `[env.<name>].region` applies.
+   */
+  region?: string;
+  /**
    * Per-environment overrides scoped to this repo, parsed from
    * [repo.<repo>.env.<env>] sections. Each entry is merged on top of the
    * top-level [env.<env>] config on a per-key basis.
@@ -119,6 +124,7 @@ function parseRepoConfig(section: Record<string, unknown>): RepoConfig {
   const config: RepoConfig = {};
   if (typeof section.group === "string") config.group = section.group;
   if (typeof section.app === "string") config.app = section.app;
+  if (typeof section.region === "string") config.region = section.region;
   if (Array.isArray(section["flatten-fields"])) {
     const fields = section["flatten-fields"].filter((f): f is string => typeof f === "string");
     config.flattenFields = fields;
@@ -200,6 +206,7 @@ function mergeRepoConfig(base: RepoConfig, override: RepoConfig | undefined): Re
     group: override.group ?? base.group,
     app: override.app ?? base.app,
     flattenFields: override.flattenFields ?? base.flattenFields,
+    region: override.region ?? base.region,
     envOverrides: override.envOverrides ?? base.envOverrides,
   };
 }
@@ -279,6 +286,7 @@ const DEFAULT_SETTINGS_TEMPLATE = `# cloudwatch-insights settings
 # Supported fields (in either [defaults] or [repo.<name>]):
 #   group           = "/{{ env }}/logs"  # log group template; {{ env }}, {{ app }} expanded at query time
 #   app             = "my-service"        # default app filter for the seeded query
+#   region          = "eu-north-1"        # AWS region fallback when no [env.<name>].region applies
 #   flatten-fields  = ["@message"]        # JSON-decode these fields and merge their keys into the row
 #
 # Environments are declared as [env.<name>] (any lower kebab-case name) and may

--- a/cloudwatch-insights/src/console-link.mts
+++ b/cloudwatch-insights/src/console-link.mts
@@ -156,3 +156,182 @@ export function logGroupArn(opts: {
 }): string {
   return `arn:aws:logs:${opts.region}:${opts.accountId}:log-group:${opts.logGroupName}`;
 }
+
+/**
+ * Inverse of {@link encodeAwsString}. Replaces `*XX` (hex byte) escapes with
+ * the corresponding bytes, then UTF-8 decodes the result. Plain ASCII bytes
+ * are kept as-is.
+ */
+export function decodeAwsString(encoded: string): string {
+  const bytes: number[] = [];
+  for (let i = 0; i < encoded.length; i++) {
+    const c = encoded[i];
+    if (c === "*") {
+      const hex = encoded.slice(i + 1, i + 3);
+      if (!/^[0-9a-fA-F]{2}$/.test(hex)) {
+        throw new Error(`invalid *XX escape at position ${i}: *${hex}`);
+      }
+      bytes.push(parseInt(hex, 16));
+      i += 2;
+    } else {
+      bytes.push(c.charCodeAt(0));
+    }
+  }
+  return new TextDecoder("utf-8").decode(new Uint8Array(bytes));
+}
+
+/**
+ * Inverse of {@link encodeRison}. Parses AWS's Rison variant into a
+ * RisonValue tree. Throws on malformed input.
+ */
+export function decodeRison(input: string): RisonValue {
+  const parser = new RisonParser(input);
+  const value = parser.parseValue();
+  if (parser.pos !== input.length) {
+    throw new Error(
+      `unexpected trailing characters at position ${parser.pos}: ${input.slice(parser.pos)}`,
+    );
+  }
+  return value;
+}
+
+class RisonParser {
+  pos = 0;
+  constructor(public src: string) {}
+
+  parseValue(): RisonValue {
+    const c = this.src[this.pos];
+    if (c === "(") {
+      this.pos++;
+      if (this.src[this.pos] === "~") {
+        return this.parseArrayBody();
+      }
+      return this.parseObjectBody();
+    }
+    if (c === "'") {
+      this.pos++;
+      return decodeAwsString(this.readUntilDelimiter());
+    }
+    return this.parseNumber();
+  }
+
+  parseArrayBody(): RisonValue[] {
+    const out: RisonValue[] = [];
+    while (this.src[this.pos] === "~") {
+      this.pos++;
+      if (this.src[this.pos] === ")") break;
+      out.push(this.parseValue());
+    }
+    if (this.src[this.pos] !== ")") {
+      throw new Error(`expected ')' at position ${this.pos}`);
+    }
+    this.pos++;
+    return out;
+  }
+
+  parseObjectBody(): { [k: string]: RisonValue } {
+    const out: { [k: string]: RisonValue } = {};
+    if (this.src[this.pos] === ")") {
+      this.pos++;
+      return out;
+    }
+    while (true) {
+      const key = decodeAwsString(this.readUntilDelimiter());
+      if (this.src[this.pos] !== "~") {
+        throw new Error(`expected '~' after key '${key}' at position ${this.pos}`);
+      }
+      this.pos++;
+      out[key] = this.parseValue();
+      const c = this.src[this.pos];
+      if (c === "~") {
+        this.pos++;
+        continue;
+      }
+      if (c === ")") {
+        this.pos++;
+        return out;
+      }
+      throw new Error(`expected '~' or ')' at position ${this.pos}`);
+    }
+  }
+
+  readUntilDelimiter(): string {
+    const start = this.pos;
+    while (this.pos < this.src.length) {
+      const c = this.src[this.pos];
+      if (c === "~" || c === ")") break;
+      this.pos++;
+    }
+    return this.src.slice(start, this.pos);
+  }
+
+  parseNumber(): number {
+    const raw = this.readUntilDelimiter();
+    const n = Number(raw);
+    if (raw.length === 0 || !Number.isFinite(n)) {
+      throw new Error(`invalid number '${raw}' at position ${this.pos - raw.length}`);
+    }
+    return n;
+  }
+}
+
+/**
+ * Parse a log-group ARN of the form
+ * `arn:aws:logs:<region>:<account>:log-group:<name>` (with an optional
+ * trailing `:*` selector). Returns null if the input doesn't match.
+ */
+export function parseLogGroupArn(arn: string): {
+  region: string;
+  accountId: string;
+  logGroupName: string;
+} | null {
+  const m = /^arn:aws:logs:([^:]+):([^:]+):log-group:([^:]+)(?::\*)?$/.exec(arn);
+  if (!m) return null;
+  return { region: m[1], accountId: m[2], logGroupName: m[3] };
+}
+
+export interface ParsedConsoleLink {
+  region: string;
+  queryDetail: Record<string, RisonValue>;
+}
+
+/**
+ * Inverse of {@link buildConsoleLink}. Extracts the region from the URL and
+ * decodes the queryDetail object from the fragment. Accepts URLs whose
+ * fragment uses either AWS's `$3F`/`$3D` encoding or standard `%3F`/`%3D`.
+ */
+export function parseConsoleLink(url: string): ParsedConsoleLink {
+  const trimmed = url.trim();
+  const hashIdx = trimmed.indexOf("#");
+  if (hashIdx < 0) throw new Error("URL has no fragment (no '#')");
+  const queryStr = trimmed.slice(0, hashIdx);
+  const fragment = trimmed.slice(hashIdx + 1);
+
+  const regionMatch = /[?&]region=([^&]+)/.exec(queryStr);
+  if (!regionMatch) throw new Error("URL is missing the ?region=... query parameter");
+  const region = decodeURIComponent(regionMatch[1]);
+
+  // Browsers often percent-encode parts of the fragment when copying the
+  // URL from the address bar (e.g. `'` → `%27`). Decode standard
+  // percent-escapes first; the AWS-specific `*XX` escapes use `*`, not `%`,
+  // so they're untouched. Then turn `$3F` / `$3D` into `?` / `=` so we can
+  // locate `queryDetail=...` reliably.
+  let normalized: string;
+  try {
+    normalized = decodeURIComponent(fragment);
+  } catch {
+    normalized = fragment;
+  }
+  normalized = normalized.replace(/\$3F/g, "?").replace(/\$3D/g, "=");
+  const m = /(?:^|[?&])queryDetail=~?(.+)$/.exec(normalized);
+  if (!m) throw new Error("fragment is missing queryDetail=...");
+  const detail = decodeRison(m[1]);
+  if (!isPlainObject(detail)) {
+    throw new Error("queryDetail is not a Rison object");
+  }
+  return { region, queryDetail: detail };
+}
+
+function isPlainObject(v: RisonValue): v is { [k: string]: RisonValue } {
+  return typeof v === "object" && v !== null && !Array.isArray(v);
+}

--- a/cloudwatch-insights/src/index.mts
+++ b/cloudwatch-insights/src/index.mts
@@ -34,6 +34,7 @@ import {
   writeResults,
 } from "./query-file.mjs";
 import { LinkValues, runLink } from "./link.mjs";
+import { ParseLinkValues, runParseLink } from "./parse-link.mjs";
 import { RawValues, runRaw } from "./raw.mjs";
 
 const DESCRIPTION = "Download logs from AWS CloudWatch Logs Insights.";
@@ -411,6 +412,45 @@ const linkCmd = define({
 });
 
 // ---------------------------------------------------------------------------
+// parse-link subcommand
+// ---------------------------------------------------------------------------
+
+const parseLinkCmd = define({
+  name: "parse-link",
+  description:
+    "Decode an AWS Console Insights URL and recreate the query state (or print a `raw` shell command with --as-raw)",
+  args: {
+    url: {
+      type: "string",
+      description: "the URL to decode (alternatively pass it as a positional, or pipe it on stdin)",
+    },
+    "as-raw": {
+      type: "boolean",
+      default: false,
+      description:
+        "print a self-contained `cloudwatch-insights raw` shell command instead of writing current.insights",
+    },
+    output: {
+      type: "string",
+      short: "o",
+      description:
+        "write the .insights file to this path instead of the current slot's current.insights",
+    },
+    quiet: {
+      type: "boolean",
+      default: false,
+      description: "suppress diagnostic output on stderr",
+    },
+  },
+  run: async (ctx) => {
+    // gunshi includes the subcommand name as the first positional; drop it
+    // so the user-supplied URL (if any) is at index 0.
+    const positionals = ((ctx.positionals ?? []) as string[]).slice(1);
+    await runParseLink(ctx.values as unknown as ParseLinkValues, positionals);
+  },
+});
+
+// ---------------------------------------------------------------------------
 // raw subcommand
 // ---------------------------------------------------------------------------
 
@@ -573,7 +613,7 @@ const main = define({
   args: {},
   run: () => {
     process.stderr.write(
-      "Usage: cloudwatch-insights <query|raw|link|show|edit-config>\n" +
+      "Usage: cloudwatch-insights <query|raw|link|parse-link|show|edit-config>\n" +
         "Run `cloudwatch-insights --help` for details.\n",
     );
     process.exit(2);
@@ -598,6 +638,7 @@ try {
       query: queryCmd,
       raw: rawCmd,
       link: linkCmd,
+      "parse-link": parseLinkCmd,
       show: showCmd,
       "edit-config": editConfigCmd,
     },

--- a/cloudwatch-insights/src/index.mts
+++ b/cloudwatch-insights/src/index.mts
@@ -34,6 +34,7 @@ import {
   writeResults,
 } from "./query-file.mjs";
 import { LinkValues, runLink } from "./link.mjs";
+import { RawValues, runRaw } from "./raw.mjs";
 
 const DESCRIPTION = "Download logs from AWS CloudWatch Logs Insights.";
 
@@ -170,7 +171,8 @@ async function runQuery(values: QueryValues): Promise<void> {
 
   const envConfig = environment ? resolveEnvConfig(settings, sectionName, environment) : {};
   const profile = values.profile ?? envConfig.awsProfile;
-  const region = values.region ?? envConfig.region ?? process.env.AWS_REGION;
+  const region =
+    values.region ?? envConfig.region ?? defaults.region ?? process.env.AWS_REGION;
   if (profile) {
     process.env.AWS_PROFILE = profile;
   }
@@ -180,8 +182,14 @@ async function runQuery(values: QueryValues): Promise<void> {
     if (profile && !values.profile) {
       process.stderr.write(`  AWS_PROFILE: ${profile} (from [env.${environment}])\n`);
     }
-    if (envConfig.region && !values.region) {
-      process.stderr.write(`  AWS region:  ${envConfig.region} (from [env.${environment}])\n`);
+    if (!values.region) {
+      if (envConfig.region) {
+        process.stderr.write(`  AWS region:  ${envConfig.region} (from [env.${environment}])\n`);
+      } else if (defaults.region) {
+        process.stderr.write(
+          `  AWS region:  ${defaults.region} (from ${sectionName ? `[repo.${sectionName}] or [defaults]` : "[defaults]"})\n`,
+        );
+      }
     }
   }
 
@@ -386,6 +394,11 @@ const linkCmd = define({
       description:
         "always emit absolute start/end timestamps in the URL, even when -t is a relative duration like 1h",
     },
+    open: {
+      type: "boolean",
+      default: false,
+      description: "open the URL in the default browser",
+    },
     quiet: {
       type: "boolean",
       default: false,
@@ -394,6 +407,62 @@ const linkCmd = define({
   },
   run: async (ctx) => {
     await runLink(ctx.values as unknown as LinkValues);
+  },
+});
+
+// ---------------------------------------------------------------------------
+// raw subcommand
+// ---------------------------------------------------------------------------
+
+const rawCmd = define({
+  name: "raw",
+  description:
+    "Run a query verbatim from a file (no templating, no front-matter, no config); write JSONL to stdout or --output",
+  args: {
+    "log-group": {
+      type: "string",
+      short: "g",
+      multiple: true,
+      description: "log group name (repeat or comma-separate; required)",
+    },
+    "query-file": {
+      type: "string",
+      short: "f",
+      description: "read query from file (use '-' for stdin; required)",
+    },
+    time: {
+      type: "string",
+      short: "t",
+      description:
+        "time range (same syntax as `query --time`). Defaults to 1h.",
+    },
+    limit: {
+      type: "number",
+      short: "l",
+      description: "maximum number of rows to return",
+    },
+    region: {
+      type: "string",
+      short: "r",
+      description: "AWS region (overrides AWS_REGION)",
+    },
+    profile: {
+      type: "string",
+      description: "AWS profile (sets AWS_PROFILE)",
+    },
+    output: {
+      type: "string",
+      short: "o",
+      description: "write JSONL results to this file instead of stdout",
+    },
+    quiet: {
+      type: "boolean",
+      default: false,
+      description: "suppress progress output on stderr",
+    },
+  },
+  run: async (ctx) => {
+    await runRaw(ctx.values as unknown as RawValues);
   },
 });
 
@@ -504,7 +573,7 @@ const main = define({
   args: {},
   run: () => {
     process.stderr.write(
-      "Usage: cloudwatch-insights <query|link|show|edit-config>\n" +
+      "Usage: cloudwatch-insights <query|raw|link|show|edit-config>\n" +
         "Run `cloudwatch-insights --help` for details.\n",
     );
     process.exit(2);
@@ -527,6 +596,7 @@ try {
     renderHeader: null,
     subCommands: {
       query: queryCmd,
+      raw: rawCmd,
       link: linkCmd,
       show: showCmd,
       "edit-config": editConfigCmd,

--- a/cloudwatch-insights/src/link.mts
+++ b/cloudwatch-insights/src/link.mts
@@ -9,6 +9,7 @@
  */
 
 import { existsSync, readFileSync } from "fs";
+import { spawn } from "child_process";
 
 import { STSClient, GetCallerIdentityCommand } from "@aws-sdk/client-sts";
 
@@ -34,6 +35,7 @@ import {
   TimeRangeParseError,
   tryParseRelativeDurationSeconds,
 } from "./time-range.mjs";
+import { hyperlink, openUrlCommand } from "./terminal.mjs";
 import {
   FrontMatter,
   currentInsightsPath,
@@ -51,6 +53,7 @@ export interface LinkValues {
   profile?: string;
   "preserve-time-window": boolean;
   "account-id"?: string;
+  open: boolean;
   quiet: boolean;
 }
 
@@ -103,7 +106,7 @@ export async function runLink(values: LinkValues): Promise<void> {
     environment ? resolveEnvConfig(settings, sectionName, environment) : {};
   const profile = values.profile ?? envConfig.awsProfile;
   const region =
-    values.region ?? envConfig.region ?? process.env.AWS_REGION;
+    values.region ?? envConfig.region ?? defaults.region ?? process.env.AWS_REGION;
 
   if (!region) {
     fail(
@@ -134,8 +137,14 @@ export async function runLink(values: LinkValues): Promise<void> {
     if (profile && !values.profile) {
       process.stderr.write(`  AWS_PROFILE: ${profile} (from [env.${environment}])\n`);
     }
-    if (envConfig.region && !values.region) {
-      process.stderr.write(`  AWS region:  ${envConfig.region} (from [env.${environment}])\n`);
+    if (!values.region) {
+      if (envConfig.region) {
+        process.stderr.write(`  AWS region:  ${envConfig.region} (from [env.${environment}])\n`);
+      } else if (defaults.region) {
+        process.stderr.write(
+          `  AWS region:  ${defaults.region} (from ${sectionName ? `[repo.${sectionName}] or [defaults]` : "[defaults]"})\n`,
+        );
+      }
     }
     process.stderr.write(`  account ID:  ${accountId}\n`);
     process.stderr.write(`  log groups:  ${logGroups.join(", ")}\n`);
@@ -150,7 +159,26 @@ export async function runLink(values: LinkValues): Promise<void> {
     time,
   });
   const url = buildConsoleLink({ region, queryDetail });
+
+  if (process.stdout.isTTY) {
+    process.stdout.write(
+      hyperlink(url, "Open in CloudWatch Logs Insights") + "\n",
+    );
+  }
   process.stdout.write(url + "\n");
+
+  if (values.open) {
+    openInBrowser(url);
+  }
+}
+
+function openInBrowser(url: string): void {
+  const { cmd, args } = openUrlCommand(url);
+  const child = spawn(cmd, args, { stdio: "ignore", detached: true });
+  child.on("error", (err) => {
+    process.stderr.write(`error: failed to open browser (${cmd}): ${err.message}\n`);
+  });
+  child.unref();
 }
 
 function chooseTimeSpec(

--- a/cloudwatch-insights/src/parse-link.mts
+++ b/cloudwatch-insights/src/parse-link.mts
@@ -70,15 +70,20 @@ export function parseLinkToState(url: string): ParsedLinkState {
   if (!Array.isArray(source) || source.length === 0) {
     throw new Error("queryDetail.source is missing or empty");
   }
-  const logGroups = source.map((arn, i) => {
-    if (typeof arn !== "string") {
+  const logGroups = source.map((entry, i) => {
+    if (typeof entry !== "string") {
       throw new Error(`queryDetail.source[${i}] is not a string`);
     }
-    const parsed = parseLogGroupArn(arn);
-    if (!parsed) {
-      throw new Error(`queryDetail.source[${i}] is not a log-group ARN: ${arn}`);
+    // The Console emits either full log-group ARNs (when queryBy=logGroupArn)
+    // or bare log-group names (when queryBy=logGroupName). Accept both.
+    if (entry.startsWith("arn:")) {
+      const parsed = parseLogGroupArn(entry);
+      if (!parsed) {
+        throw new Error(`queryDetail.source[${i}] is not a log-group ARN: ${entry}`);
+      }
+      return parsed.logGroupName;
     }
-    return parsed.logGroupName;
+    return entry;
   });
 
   return {

--- a/cloudwatch-insights/src/parse-link.mts
+++ b/cloudwatch-insights/src/parse-link.mts
@@ -1,0 +1,209 @@
+/**
+ * `cloudwatch-insights parse-link` — inverse of the `link` subcommand.
+ *
+ * Default behavior: write the query body, log groups, time and (optional)
+ * region into `current.insights` for the current slot, so a subsequent
+ * `cloudwatch-insights query` would re-run the same query.
+ *
+ * With `--as-raw`: print a self-contained `cloudwatch-insights raw …`
+ * shell command (a heredoc piping the query body into stdin) and do not
+ * touch any state files. Useful for sharing a one-off invocation.
+ */
+
+import { mkdirSync, writeFileSync } from "fs";
+import { dirname } from "path";
+import { stringify as stringifyToml } from "smol-toml";
+
+import {
+  parseConsoleLink,
+  parseLogGroupArn,
+  RisonValue,
+} from "./console-link.mjs";
+import { currentInsightsPath } from "./query-file.mjs";
+
+export interface ParseLinkValues {
+  url?: string;
+  "as-raw": boolean;
+  output?: string;
+  quiet: boolean;
+}
+
+export interface ParsedLinkState {
+  region: string;
+  logGroups: string[];
+  time: string;
+  query: string;
+}
+
+export async function runParseLink(
+  values: ParseLinkValues,
+  positionals: string[],
+): Promise<void> {
+  const url = await resolveUrl(values, positionals);
+  const state = parseLinkToState(url);
+
+  if (values["as-raw"]) {
+    process.stdout.write(buildRawCommand(state) + "\n");
+    return;
+  }
+
+  const path = values.output ?? currentInsightsPath();
+  writeInsightsFile(path, state);
+  if (!values.quiet) {
+    process.stderr.write(`Wrote ${path}\n`);
+    process.stderr.write(`  region:     ${state.region}\n`);
+    process.stderr.write(`  log groups: ${state.logGroups.join(", ")}\n`);
+    process.stderr.write(`  time:       ${state.time}\n`);
+  }
+}
+
+/** Decode an AWS Console link into the values needed to recreate the query. */
+export function parseLinkToState(url: string): ParsedLinkState {
+  const { region, queryDetail } = parseConsoleLink(url);
+
+  const editorString = queryDetail.editorString;
+  if (typeof editorString !== "string") {
+    throw new Error("queryDetail.editorString is missing or not a string");
+  }
+
+  const source = queryDetail.source;
+  if (!Array.isArray(source) || source.length === 0) {
+    throw new Error("queryDetail.source is missing or empty");
+  }
+  const logGroups = source.map((arn, i) => {
+    if (typeof arn !== "string") {
+      throw new Error(`queryDetail.source[${i}] is not a string`);
+    }
+    const parsed = parseLogGroupArn(arn);
+    if (!parsed) {
+      throw new Error(`queryDetail.source[${i}] is not a log-group ARN: ${arn}`);
+    }
+    return parsed.logGroupName;
+  });
+
+  return {
+    region,
+    logGroups,
+    time: timeFromQueryDetail(queryDetail),
+    query: editorString,
+  };
+}
+
+function timeFromQueryDetail(detail: Record<string, RisonValue>): string {
+  const timeType = detail.timeType;
+  if (timeType === "RELATIVE") {
+    const start = detail.start;
+    if (typeof start !== "number") {
+      throw new Error("RELATIVE time has non-numeric start");
+    }
+    const unit = detail.unit;
+    const seconds = unit === "milliseconds" ? Math.round(-start / 1000) : -start;
+    return formatRelativeDuration(seconds);
+  }
+  if (timeType === "ABSOLUTE") {
+    const start = detail.start;
+    const end = detail.end;
+    if (typeof start !== "number" || typeof end !== "number") {
+      throw new Error("ABSOLUTE time has non-numeric start/end");
+    }
+    return `${new Date(start).toISOString()}/${new Date(end).toISOString()}`;
+  }
+  throw new Error(`unknown timeType: ${JSON.stringify(timeType)}`);
+}
+
+/**
+ * Format a whole number of seconds as the largest exact unit understood by
+ * the time-range parser: w/d/h/m, falling back to s when nothing divides
+ * evenly. (1h beats 60m beats 3600s.)
+ */
+export function formatRelativeDuration(totalSeconds: number): string {
+  if (!Number.isFinite(totalSeconds) || totalSeconds < 0) {
+    throw new Error(`invalid duration: ${totalSeconds}`);
+  }
+  if (totalSeconds === 0) return "0s";
+  const units: Array<[string, number]> = [
+    ["w", 7 * 86_400],
+    ["d", 86_400],
+    ["h", 3_600],
+    ["m", 60],
+    ["s", 1],
+  ];
+  for (const [suffix, secs] of units) {
+    if (totalSeconds % secs === 0) {
+      return `${totalSeconds / secs}${suffix}`;
+    }
+  }
+  return `${totalSeconds}s`;
+}
+
+function writeInsightsFile(path: string, state: ParsedLinkState): void {
+  mkdirSync(dirname(path), { recursive: true });
+  const fm: Record<string, unknown> = {
+    time: state.time,
+    "log-group": state.logGroups.length === 1 ? state.logGroups[0] : state.logGroups,
+  };
+  const contents = `${stringifyToml(fm)}\n---\n${state.query}\n`;
+  writeFileSync(path, contents, "utf8");
+}
+
+/**
+ * Build a single-line shell command that runs the same query via `raw`,
+ * piping the query body in via stdin (a quoted heredoc, so $… and backslash
+ * escapes inside the query are preserved verbatim).
+ */
+export function buildRawCommand(state: ParsedLinkState): string {
+  const args = ["cloudwatch-insights", "raw"];
+  args.push("-r", shellQuote(state.region));
+  for (const lg of state.logGroups) {
+    args.push("-g", shellQuote(lg));
+  }
+  args.push("-t", shellQuote(state.time));
+  args.push("-f", "-");
+  // Quoted heredoc ('EOF') so the body is not subject to shell expansion.
+  return `${args.join(" ")} <<'EOF'\n${state.query}\nEOF`;
+}
+
+function shellQuote(s: string): string {
+  if (s === "") return "''";
+  // Safe set: alphanumeric plus a handful of innocuous punctuation that the
+  // shell never expands.
+  if (/^[A-Za-z0-9_./:@%+,=-]+$/.test(s)) return s;
+  return `'${s.replace(/'/g, "'\\''")}'`;
+}
+
+async function resolveUrl(
+  values: ParseLinkValues,
+  positionals: string[],
+): Promise<string> {
+  if (values.url && positionals.length > 0) {
+    fail("pass either --url or a positional URL, not both", 2);
+  }
+  let url = values.url ?? positionals[0];
+  if (!url) {
+    // Read from stdin as a fallback so users can pipe pbpaste / xclip into us.
+    if (!process.stdin.isTTY) {
+      url = await readAllStdin();
+    }
+  }
+  if (!url) {
+    fail("no URL given — pass it as the first argument, --url, or via stdin", 2);
+  }
+  return url.trim();
+}
+
+async function readAllStdin(): Promise<string> {
+  return new Promise((resolve, reject) => {
+    let data = "";
+    process.stdin.setEncoding("utf8");
+    process.stdin.on("data", (chunk) => {
+      data += chunk;
+    });
+    process.stdin.on("end", () => resolve(data));
+    process.stdin.on("error", reject);
+  });
+}
+
+function fail(message: string, code = 1): never {
+  process.stderr.write(`error: ${message}\n`);
+  process.exit(code);
+}

--- a/cloudwatch-insights/src/raw.mts
+++ b/cloudwatch-insights/src/raw.mts
@@ -1,0 +1,109 @@
+/**
+ * `cloudwatch-insights raw` — execute a query taken verbatim from a file.
+ *
+ * No templating, no front-matter parsing, no config lookup, no flatten-fields
+ * post-processing, no editor, no run-results bookkeeping. The file's contents
+ * are sent to CloudWatch as-is, and the resulting JSONL is written to stdout
+ * (or to `--output` if given).
+ */
+
+import { createWriteStream, readFileSync } from "fs";
+import { CloudWatchLogsClient } from "@aws-sdk/client-cloudwatch-logs";
+
+import { runInsightsQuery } from "./insights.mjs";
+import { parseTimeRange, TimeRangeParseError } from "./time-range.mjs";
+
+export interface RawValues {
+  "log-group"?: string[];
+  time?: string;
+  "query-file"?: string;
+  limit?: number;
+  region?: string;
+  profile?: string;
+  output?: string;
+  quiet: boolean;
+}
+
+export async function runRaw(values: RawValues): Promise<void> {
+  if (!values["query-file"]) {
+    fail("--query-file/-f is required", 2);
+  }
+  const logGroups = flatten((values["log-group"] ?? []).map((s) => s.split(",")))
+    .map((s) => s.trim())
+    .filter(Boolean);
+  if (logGroups.length === 0) {
+    fail("--log-group/-g is required (repeat or comma-separate)", 2);
+  }
+
+  const source = values["query-file"] === "-" ? 0 : values["query-file"]!;
+  const queryString = readFileSync(source, "utf8");
+
+  const timeExpr = values.time ?? "1h";
+  let range;
+  try {
+    range = parseTimeRange(timeExpr);
+  } catch (err) {
+    if (err instanceof TimeRangeParseError) fail(err.message, 2);
+    throw err;
+  }
+
+  if (values.profile) {
+    process.env.AWS_PROFILE = values.profile;
+  }
+  const region = values.region ?? process.env.AWS_REGION;
+  const client = new CloudWatchLogsClient({ region });
+
+  if (!values.quiet) {
+    process.stderr.write(
+      `Querying ${logGroups.length} log group(s) from ${range.startTime.toISOString()} ` +
+        `to ${range.endTime.toISOString()}\n`,
+    );
+    process.stderr.write(`  log groups: ${logGroups.join(", ")}\n`);
+  }
+
+  let lastStatus = "";
+  const result = await runInsightsQuery({
+    client,
+    logGroups,
+    queryString,
+    startTime: range.startTime,
+    endTime: range.endTime,
+    limit: values.limit,
+    onStatus: (status) => {
+      if (values.quiet || status === lastStatus) return;
+      lastStatus = String(status);
+      process.stderr.write(`  status: ${status}\n`);
+    },
+  });
+
+  const contents = result.rows.map((r) => JSON.stringify(r) + "\n").join("");
+  if (values.output) {
+    await new Promise<void>((resolve, reject) => {
+      const stream = createWriteStream(values.output!, { encoding: "utf8" });
+      stream.on("error", reject);
+      stream.on("finish", resolve);
+      stream.end(contents);
+    });
+  } else {
+    process.stdout.write(contents);
+  }
+
+  if (!values.quiet) {
+    const { recordsMatched, recordsScanned, bytesScanned } = result.statistics ?? {};
+    process.stderr.write(
+      `Done. ${result.rows.length} rows written (matched=${recordsMatched ?? "?"} ` +
+        `scanned=${recordsScanned ?? "?"} bytes=${bytesScanned ?? "?"}).\n`,
+    );
+  }
+}
+
+function flatten<T>(arrays: T[][]): T[] {
+  const out: T[] = [];
+  for (const a of arrays) out.push(...a);
+  return out;
+}
+
+function fail(message: string, code = 1): never {
+  process.stderr.write(`error: ${message}\n`);
+  process.exit(code);
+}

--- a/cloudwatch-insights/src/terminal.mts
+++ b/cloudwatch-insights/src/terminal.mts
@@ -1,0 +1,36 @@
+/**
+ * Tiny terminal-escape helpers.
+ *
+ * `hyperlink` wraps text in an OSC 8 hyperlink escape sequence:
+ *   \x1b]8;;<URL>\x1b\\<TEXT>\x1b]8;;\x1b\\
+ * Terminals that understand OSC 8 (iTerm2, recent VS Code, GNOME Terminal,
+ * WezTerm, …) render <TEXT> as a clickable link to <URL>; ones that don't
+ * simply display <TEXT>.
+ *
+ * Reference: https://gist.github.com/egmontkob/eb114294efbcd5adb1944c9f3cb5feda
+ */
+const ESC = "\x1b";
+const ST = `${ESC}\\`;
+
+export function hyperlink(url: string, text: string): string {
+  return `${ESC}]8;;${url}${ST}${text}${ESC}]8;;${ST}`;
+}
+
+/**
+ * Per-platform command for opening a URL in the user's default browser.
+ * Exported for unit tests; the runtime caller spawns the result.
+ */
+export function openUrlCommand(
+  url: string,
+  platform: NodeJS.Platform = process.platform,
+): { cmd: string; args: string[] } {
+  switch (platform) {
+    case "darwin":
+      return { cmd: "open", args: [url] };
+    case "win32":
+      // `start` is a cmd.exe builtin; the empty "" is the window title.
+      return { cmd: "cmd", args: ["/c", "start", "", url] };
+    default:
+      return { cmd: "xdg-open", args: [url] };
+  }
+}

--- a/cloudwatch-insights/test/config.test.mts
+++ b/cloudwatch-insights/test/config.test.mts
@@ -165,6 +165,67 @@ test("resolveEnvConfig: returns empty when no top-level [env.<env>] and no overr
   assert.deepEqual(resolveEnvConfig(settings, "foo", "prod"), {});
 });
 
+test("parseSettings: parses region in [defaults] and [repo.<name>]", () => {
+  const settings = parseSettings(
+    [
+      "[defaults]",
+      'region = "eu-north-1"',
+      "",
+      "[repo.foo]",
+      'region = "us-east-1"',
+    ].join("\n"),
+  );
+  assert.equal(settings.defaults.region, "eu-north-1");
+  assert.equal(settings.repos["foo"].region, "us-east-1");
+});
+
+test("resolveRepoDefaults: per-repo region overrides defaults region", () => {
+  const tmpRoot = realpathSync(mkdtempSync(join(tmpdir(), "cwi-region-")));
+  try {
+    const repoRoot = join(tmpRoot, "my-service");
+    mkdirSync(repoRoot);
+    assert.equal(
+      spawnSync("git", ["init", "-q", "-b", "main"], { cwd: repoRoot }).status,
+      0,
+    );
+
+    const settings = loadSettings(writeSettings(tmpRoot, [
+      "[defaults]",
+      'region = "eu-north-1"',
+      "",
+      "[repo.my-service]",
+      'region = "us-east-1"',
+    ].join("\n")));
+
+    const { defaults } = resolveRepoDefaults(settings, repoRoot);
+    assert.equal(defaults.region, "us-east-1");
+  } finally {
+    rmSync(tmpRoot, { recursive: true, force: true });
+  }
+});
+
+test("resolveRepoDefaults: defaults region inherited when no per-repo override", () => {
+  const tmpRoot = realpathSync(mkdtempSync(join(tmpdir(), "cwi-region-inherit-")));
+  try {
+    const repoRoot = join(tmpRoot, "other-service");
+    mkdirSync(repoRoot);
+    assert.equal(
+      spawnSync("git", ["init", "-q", "-b", "main"], { cwd: repoRoot }).status,
+      0,
+    );
+
+    const settings = loadSettings(writeSettings(tmpRoot, [
+      "[defaults]",
+      'region = "eu-north-1"',
+    ].join("\n")));
+
+    const { defaults } = resolveRepoDefaults(settings, repoRoot);
+    assert.equal(defaults.region, "eu-north-1");
+  } finally {
+    rmSync(tmpRoot, { recursive: true, force: true });
+  }
+});
+
 test("parseSettings: filters non-string entries from flatten-fields", () => {
   const settings = parseSettings(
     [

--- a/cloudwatch-insights/test/console-link.test.mts
+++ b/cloudwatch-insights/test/console-link.test.mts
@@ -4,9 +4,13 @@ import assert from "node:assert/strict";
 import {
   buildConsoleLink,
   buildQueryDetail,
+  decodeAwsString,
+  decodeRison,
   encodeAwsString,
   encodeRison,
   logGroupArn,
+  parseConsoleLink,
+  parseLogGroupArn,
   type RisonValue,
 } from "../src/console-link.mjs";
 
@@ -166,5 +170,167 @@ test("encodeRison round-trips arrays of strings with special chars", () => {
   assert.equal(
     encodeRison(["a:b", "c/d"]),
     "(~'a*3ab~'c*2fd)",
+  );
+});
+
+test("decodeAwsString: inverse of encodeAwsString", () => {
+  for (const s of [
+    "abc",
+    " ",
+    "@",
+    "@timestamp",
+    "fields @timestamp, @message\n| sort @timestamp desc",
+    "é",
+    "✓",
+    "*~()",
+  ]) {
+    assert.equal(decodeAwsString(encodeAwsString(s)), s, `round-trip: ${JSON.stringify(s)}`);
+  }
+});
+
+test("decodeAwsString: rejects malformed *XX escapes", () => {
+  assert.throws(() => decodeAwsString("*"), /invalid \*XX/);
+  assert.throws(() => decodeAwsString("*g0"), /invalid \*XX/);
+});
+
+test("decodeRison: inverse of encodeRison for primitives, arrays, objects", () => {
+  const cases: RisonValue[] = [
+    0,
+    -3600,
+    "UTC",
+    "fields @timestamp, @message\n| limit 200",
+    [],
+    ["a", "b"],
+    { end: 0, start: -3600, tz: "UTC" },
+    {
+      end: 0,
+      start: -3600,
+      timeType: "RELATIVE",
+      tz: "UTC",
+      unit: "seconds",
+      editorString: "fields @timestamp",
+      source: ["arn:aws:logs:eu-north-1:1:log-group:/x"],
+      lang: "CWLI",
+    },
+  ];
+  for (const v of cases) {
+    assert.deepEqual(decodeRison(encodeRison(v)), v);
+  }
+});
+
+test("decodeRison: round-trips the full Console-format example", () => {
+  const original: Record<string, RisonValue> = {
+    end: 0,
+    start: -3600,
+    timeType: "RELATIVE",
+    tz: "UTC",
+    unit: "seconds",
+    editorString:
+      "fields @timestamp, @message\n" +
+      "| sort @timestamp desc\n" +
+      "| filter app = 'installer-notification'\n" +
+      "| limit 200",
+    queryId: "dae7095d-9b56-4ec6-ab9a-d2ffb41b0fdb",
+    source: ["arn:aws:logs:eu-north-1:361629632765:log-group:/eks/uat/team-icc"],
+    lang: "CWLI",
+    logClass: "STANDARD",
+    queryBy: "logGroupName",
+  };
+  assert.deepEqual(decodeRison(encodeRison(original)), original);
+});
+
+test("decodeRison: parses ABSOLUTE timeType with epoch-ms numbers", () => {
+  const encoded = encodeRison({
+    end: 1700003600000,
+    start: 1700000000000,
+    timeType: "ABSOLUTE",
+    unit: "milliseconds",
+  });
+  assert.deepEqual(decodeRison(encoded), {
+    end: 1700003600000,
+    start: 1700000000000,
+    timeType: "ABSOLUTE",
+    unit: "milliseconds",
+  });
+});
+
+test("decodeRison: rejects trailing garbage", () => {
+  assert.throws(() => decodeRison("(a~1)x"), /trailing/);
+});
+
+test("parseLogGroupArn: extracts region/account/name", () => {
+  assert.deepEqual(
+    parseLogGroupArn("arn:aws:logs:eu-north-1:361629632765:log-group:/eks/uat/team-icc"),
+    {
+      region: "eu-north-1",
+      accountId: "361629632765",
+      logGroupName: "/eks/uat/team-icc",
+    },
+  );
+  assert.equal(parseLogGroupArn("not-an-arn"), null);
+  assert.equal(
+    parseLogGroupArn("arn:aws:s3:::my-bucket"),
+    null,
+    "non-logs ARN rejected",
+  );
+});
+
+test("parseLogGroupArn: tolerates trailing :* selector", () => {
+  assert.deepEqual(
+    parseLogGroupArn("arn:aws:logs:eu-north-1:1:log-group:/x:*"),
+    { region: "eu-north-1", accountId: "1", logGroupName: "/x" },
+  );
+});
+
+test("parseConsoleLink: round-trips a Console-generated URL", () => {
+  const queryDetail: Record<string, RisonValue> = {
+    end: 0,
+    start: -3600,
+    timeType: "RELATIVE",
+    tz: "UTC",
+    unit: "seconds",
+    editorString:
+      "fields @timestamp, @message\n" +
+      "| sort @timestamp desc\n" +
+      "| filter app = 'installer-notification'\n" +
+      "| limit 200",
+    queryId: "dae7095d-9b56-4ec6-ab9a-d2ffb41b0fdb",
+    source: ["arn:aws:logs:eu-north-1:361629632765:log-group:/eks/uat/team-icc"],
+    lang: "CWLI",
+    logClass: "STANDARD",
+    queryBy: "logGroupName",
+  };
+  const url = buildConsoleLink({ region: "eu-north-1", queryDetail });
+  const parsed = parseConsoleLink(url);
+  assert.equal(parsed.region, "eu-north-1");
+  assert.deepEqual(parsed.queryDetail, queryDetail);
+});
+
+test("parseConsoleLink: tolerates percent-encoded $3F/$3D", () => {
+  const queryDetail: Record<string, RisonValue> = {
+    end: 0,
+    start: -60,
+    timeType: "RELATIVE",
+    tz: "UTC",
+    unit: "seconds",
+    editorString: "fields @timestamp",
+    source: ["arn:aws:logs:eu-north-1:1:log-group:/x"],
+    lang: "CWLI",
+    logClass: "STANDARD",
+    queryBy: "logGroupName",
+  };
+  const original = buildConsoleLink({ region: "eu-north-1", queryDetail });
+  const percentEncoded = original
+    .replace("$3F", "%3F")
+    .replace("$3D", "%3D");
+  const parsed = parseConsoleLink(percentEncoded);
+  assert.equal(parsed.region, "eu-north-1");
+  assert.deepEqual(parsed.queryDetail, queryDetail);
+});
+
+test("parseConsoleLink: rejects URLs without queryDetail", () => {
+  assert.throws(
+    () => parseConsoleLink("https://eu-north-1.console.aws.amazon.com/cloudwatch/home?region=eu-north-1#logsV2:logs-insights"),
+    /queryDetail/,
   );
 });

--- a/cloudwatch-insights/test/parse-link.test.mts
+++ b/cloudwatch-insights/test/parse-link.test.mts
@@ -77,6 +77,21 @@ test("parseLinkToState: absolute time emits ISO range with '/' separator", () =>
   );
 });
 
+test("parseLinkToState: accepts bare log-group names in source (queryBy=logGroupName)", () => {
+  // Real Console URLs emit bare names rather than ARNs when the user is
+  // querying by log-group name; reproduce the structure here.
+  const detail = buildQueryDetail({
+    query: "fields @timestamp",
+    logGroupArns: [], // placeholder; we'll override below
+    time: { kind: "relative", secondsBack: 60 },
+  });
+  detail.source = ["/eks/systest/team-icc"];
+  const url = buildConsoleLink({ region: "eu-north-1", queryDetail: detail });
+  const state = parseLinkToState(url);
+  assert.deepEqual(state.logGroups, ["/eks/systest/team-icc"]);
+  assert.equal(state.region, "eu-north-1");
+});
+
 test("parseLinkToState: rejects URL with no log groups", () => {
   // Build a URL by hand and strip the source key
   const detail = buildQueryDetail({

--- a/cloudwatch-insights/test/parse-link.test.mts
+++ b/cloudwatch-insights/test/parse-link.test.mts
@@ -1,0 +1,153 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, readFileSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+
+import {
+  buildRawCommand,
+  formatRelativeDuration,
+  parseLinkToState,
+} from "../src/parse-link.mjs";
+import {
+  buildConsoleLink,
+  buildQueryDetail,
+  logGroupArn,
+} from "../src/console-link.mjs";
+import { parseQueryFile } from "../src/query-file.mjs";
+import { writeFileSync } from "fs";
+
+function buildLink(opts: {
+  region: string;
+  accountId: string;
+  logGroups: string[];
+  query: string;
+  time: { kind: "relative"; secondsBack: number } | { kind: "absolute"; startMs: number; endMs: number };
+}): string {
+  const arns = opts.logGroups.map((lg) =>
+    logGroupArn({ region: opts.region, accountId: opts.accountId, logGroupName: lg }),
+  );
+  const detail = buildQueryDetail({
+    query: opts.query,
+    logGroupArns: arns,
+    time: opts.time,
+  });
+  return buildConsoleLink({ region: opts.region, queryDetail: detail });
+}
+
+test("formatRelativeDuration: picks the largest exact unit", () => {
+  assert.equal(formatRelativeDuration(60), "1m");
+  assert.equal(formatRelativeDuration(3600), "1h");
+  assert.equal(formatRelativeDuration(86_400), "1d");
+  assert.equal(formatRelativeDuration(7 * 86_400), "1w");
+  assert.equal(formatRelativeDuration(2 * 3600), "2h");
+  assert.equal(formatRelativeDuration(90), "90s"); // not divisible by 60
+  assert.equal(formatRelativeDuration(45), "45s");
+  assert.equal(formatRelativeDuration(0), "0s");
+});
+
+test("parseLinkToState: relative time, single log group", () => {
+  const url = buildLink({
+    region: "eu-north-1",
+    accountId: "361629632765",
+    logGroups: ["/eks/uat/team-icc"],
+    query: "fields @timestamp, @message\n| limit 200",
+    time: { kind: "relative", secondsBack: 3600 },
+  });
+  const state = parseLinkToState(url);
+  assert.equal(state.region, "eu-north-1");
+  assert.deepEqual(state.logGroups, ["/eks/uat/team-icc"]);
+  assert.equal(state.time, "1h");
+  assert.equal(state.query, "fields @timestamp, @message\n| limit 200");
+});
+
+test("parseLinkToState: absolute time emits ISO range with '/' separator", () => {
+  const url = buildLink({
+    region: "eu-north-1",
+    accountId: "1",
+    logGroups: ["/a", "/b"],
+    query: "fields @timestamp",
+    time: { kind: "absolute", startMs: 1700000000000, endMs: 1700003600000 },
+  });
+  const state = parseLinkToState(url);
+  assert.deepEqual(state.logGroups, ["/a", "/b"]);
+  assert.equal(
+    state.time,
+    `${new Date(1700000000000).toISOString()}/${new Date(1700003600000).toISOString()}`,
+  );
+});
+
+test("parseLinkToState: rejects URL with no log groups", () => {
+  // Build a URL by hand and strip the source key
+  const detail = buildQueryDetail({
+    query: "fields @timestamp",
+    logGroupArns: ["arn:aws:logs:eu-north-1:1:log-group:/x"],
+    time: { kind: "relative", secondsBack: 60 },
+  });
+  delete detail.source;
+  const url = buildConsoleLink({ region: "eu-north-1", queryDetail: detail });
+  assert.throws(() => parseLinkToState(url), /source/);
+});
+
+test("buildRawCommand: emits a single-line command + heredoc body", () => {
+  const cmd = buildRawCommand({
+    region: "eu-north-1",
+    logGroups: ["/eks/uat/team-icc"],
+    time: "1h",
+    query: "fields @timestamp\n| limit 200",
+  });
+  assert.equal(
+    cmd,
+    "cloudwatch-insights raw -r eu-north-1 -g /eks/uat/team-icc -t 1h -f - <<'EOF'\n" +
+      "fields @timestamp\n| limit 200\nEOF",
+  );
+});
+
+test("buildRawCommand: shell-quotes values with spaces or special chars", () => {
+  const cmd = buildRawCommand({
+    region: "eu-north-1",
+    logGroups: ["/with space", "/another"],
+    time: "2026-04-22T13:00:00Z/2026-04-22T14:00:00Z",
+    query: "fields @timestamp",
+  });
+  assert.match(cmd, /-g '\/with space' -g \/another /);
+  // ISO time has only safe chars (alnum, :/.+-Z) so it stays unquoted
+  assert.match(cmd, /-t 2026-04-22T13:00:00Z\/2026-04-22T14:00:00Z /);
+});
+
+test("buildRawCommand: escapes single-quotes inside values", () => {
+  const cmd = buildRawCommand({
+    region: "x",
+    logGroups: ["/it's"],
+    time: "1h",
+    query: "q",
+  });
+  assert.match(cmd, /-g '\/it'\\''s'/);
+});
+
+test("end-to-end: link → parse-link → recreated current.insights", () => {
+  const url = buildLink({
+    region: "eu-north-1",
+    accountId: "361629632765",
+    logGroups: ["/eks/uat/team-icc"],
+    query: "fields @timestamp, @message\n| sort @timestamp desc\n| limit 200",
+    time: { kind: "relative", secondsBack: 5 * 3600 },
+  });
+  const state = parseLinkToState(url);
+
+  const tmp = mkdtempSync(join(tmpdir(), "cwi-parse-link-"));
+  try {
+    const path = join(tmp, "current.insights");
+    // Mirror what runParseLink writes (front-matter + body), so we test the
+    // shape of the file the user would edit and re-run via `query`.
+    const fm = `time = "${state.time}"\nlog-group = "${state.logGroups[0]}"\n`;
+    writeFileSync(path, `${fm}---\n${state.query}\n`, "utf8");
+
+    const parsed = parseQueryFile(readFileSync(path, "utf8"));
+    assert.equal(parsed.frontMatter.time, "5h");
+    assert.equal(parsed.frontMatter["log-group"], "/eks/uat/team-icc");
+    assert.equal(parsed.body, state.query);
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});

--- a/cloudwatch-insights/test/terminal.test.mts
+++ b/cloudwatch-insights/test/terminal.test.mts
@@ -1,0 +1,43 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { hyperlink, openUrlCommand } from "../src/terminal.mjs";
+
+test("hyperlink: wraps text in OSC 8 escape sequence with ST terminator", () => {
+  const url = "https://example.com/foo";
+  const text = "click me";
+  const result = hyperlink(url, text);
+  assert.equal(result, `\x1b]8;;${url}\x1b\\${text}\x1b]8;;\x1b\\`);
+});
+
+test("hyperlink: empty text still produces a well-formed sequence", () => {
+  assert.equal(
+    hyperlink("https://x", ""),
+    "\x1b]8;;https://x\x1b\\\x1b]8;;\x1b\\",
+  );
+});
+
+test("openUrlCommand: darwin uses `open`", () => {
+  assert.deepEqual(openUrlCommand("https://x", "darwin"), {
+    cmd: "open",
+    args: ["https://x"],
+  });
+});
+
+test("openUrlCommand: win32 uses cmd /c start with empty title", () => {
+  assert.deepEqual(openUrlCommand("https://x", "win32"), {
+    cmd: "cmd",
+    args: ["/c", "start", "", "https://x"],
+  });
+});
+
+test("openUrlCommand: linux/other uses xdg-open", () => {
+  assert.deepEqual(openUrlCommand("https://x", "linux"), {
+    cmd: "xdg-open",
+    args: ["https://x"],
+  });
+  assert.deepEqual(openUrlCommand("https://x", "freebsd"), {
+    cmd: "xdg-open",
+    args: ["https://x"],
+  });
+});


### PR DESCRIPTION
## Summary

This PR adds several new features and improvements to cloudwatch-insights:

1. A new `raw` subcommand for executing CloudWatch Insights queries verbatim from files without templating or config processing
2. An `--open` flag for the `link` subcommand to open URLs in the default browser
3. Support for configuring AWS region in `[defaults]` and `[repo.<name>]` config sections
4. Terminal escape sequence helpers for rendering clickable hyperlinks in compatible terminals

## Key Changes

- **New `raw` subcommand** (`src/raw.mts`): Executes queries directly from files with minimal processing. Supports `--log-group`, `--query-file` (including stdin via `-`), `--time`, `--limit`, `--region`, `--profile`, and `--output` flags. Results are written as JSONL to stdout or a specified file.

- **Terminal helpers** (`src/terminal.mts`): Added `hyperlink()` function to wrap text in OSC 8 escape sequences for clickable links in compatible terminals, and `openUrlCommand()` to generate platform-specific commands for opening URLs in the default browser.

- **Enhanced `link` subcommand**: 
  - Added `--open` flag to automatically open the generated CloudWatch Console URL in the default browser
  - When stdout is a TTY, the URL is now rendered as an OSC 8 clickable hyperlink above the raw URL text
  - Updated region resolution to include `defaults.region` as a fallback

- **Region configuration support**: 
  - Added `region` field to `RepoConfig` interface
  - Region can now be specified in `[defaults]` and `[repo.<name>]` sections
  - Resolution order: `--region` > `[env.<name>].region` > `[repo.<name>].region` > `[defaults].region` > `AWS_REGION`
  - Updated both `query` and `link` subcommands to use the new region fallback chain

- **Config parsing**: Updated `parseRepoConfig()` to extract and validate the `region` field from config sections

- **Tests**: Added comprehensive test coverage for region configuration inheritance and terminal escape sequence generation

- **Documentation**: Updated README with examples and descriptions of the new `raw` and `link` subcommands, and documented the new `region` config option

## Implementation Details

- The `raw` subcommand reuses existing `runInsightsQuery()` infrastructure but skips all the query-file templating, front-matter parsing, and post-processing that the `query` subcommand performs
- Browser opening is done via `child_process.spawn()` with `stdio: "ignore"` and `detached: true` to avoid blocking the CLI
- OSC 8 hyperlinks gracefully degrade in terminals that don't support them (the text is still displayed)
- Region resolution logic is now consistent across `query` and `link` subcommands

https://claude.ai/code/session_01Q5VnNB4kTJT6q72HcYA1rR