### PR TITLE
cloudwatch-insights: copy-link/paste-link, dry-run, live progress

### DIFF
--- a/cloudwatch-insights/README.md
+++ b/cloudwatch-insights/README.md
@@ -22,8 +22,8 @@ This builds the TypeScript source and installs the `cloudwatch-insights` command
 ```
 cloudwatch-insights query [options]       run a query
 cloudwatch-insights raw [options]         run a query verbatim from a file (no templating, no config)
-cloudwatch-insights link [options]        print a shareable AWS Console URL
-cloudwatch-insights parse-link <url>      decode a Console URL into current.insights (or a `raw` command)
+cloudwatch-insights copy-link [options]   copy a shareable AWS Console URL to the pasteboard
+cloudwatch-insights paste-link [url]      decode a Console URL (default: from pasteboard) into current.insights
 cloudwatch-insights show                  stream the latest run to stdout
 cloudwatch-insights edit-config           edit the per-repo config
 ```
@@ -62,6 +62,12 @@ jq . < "$last"
 
 After every successful run the symlink `~/.skagedal-tools/cloudwatch-insights/latest-run.jsonl` is updated to point at the new file.
 
+While the query runs, a single status line on stderr (`status: Running (scanned 1.2M records, 456 MiB)`) is rewritten in place from the polled `GetQueryResults` statistics. On a non-TTY stderr, status changes are appended one per line instead.
+
+After the query completes, an `Open in AWS Console` clickable hyperlink is printed to stderr (when stderr is a TTY), pointing at the same query in the CloudWatch Logs Insights Console. Off-TTY, the raw URL is printed instead.
+
+Set `dry = true` in the front-matter to skip the AWS round-trip — the query won't execute, but the resolved log groups, time range, and Console link are still printed. Useful for previewing a query before running it.
+
 ### `raw`
 
 ```sh
@@ -74,29 +80,31 @@ Runs a query verbatim from `--query-file`/`-f` (use `-` for stdin). No front-mat
 
 Results are written to stdout as JSONL, or to `--output`/`-o` if given. Required: `--query-file` and at least one `--log-group`.
 
-### `link`
+### `copy-link`
 
 ```sh
-cloudwatch-insights link
-cloudwatch-insights link --open                  # also open in default browser
-cloudwatch-insights link --preserve-time-window
+cloudwatch-insights copy-link                       # copies URL to the pasteboard
+cloudwatch-insights copy-link --raw                 # just print the URL, don't touch the pasteboard
+cloudwatch-insights copy-link --open                # also open in the default browser
+cloudwatch-insights copy-link --preserve-time-window
 ```
 
-Prints a shareable AWS Console URL for the query that `cloudwatch-insights query` would otherwise run. When stdout is a TTY, the URL is also rendered as an [OSC 8 clickable hyperlink](https://gist.github.com/egmontkob/eb114294efbcd5adb1944c9f3cb5feda) above the raw URL — terminals that understand the escape sequence (iTerm2, recent VS Code, GNOME Terminal, WezTerm, …) make it click-to-open. Pass `--open` to additionally open the URL in your default browser.
+Copies a shareable AWS Console URL for the query that `cloudwatch-insights query` would otherwise run to the system pasteboard (`pbcopy` on macOS, `clip` on Windows, `wl-copy` / `xclip` / `xsel` on Linux). Outputs `AWS Console link copied to pasteboard. Open directly` — and on a TTY `Open directly` is rendered as an [OSC 8 clickable hyperlink](https://gist.github.com/egmontkob/eb114294efbcd5adb1944c9f3cb5feda) so terminals that support the escape sequence (iTerm2, recent VS Code, GNOME Terminal, WezTerm, …) let you click straight through. Pass `--raw` to skip the pasteboard and print only the URL — handy for piping into other tools. `--open` additionally opens the URL in your default browser.
 
-### `parse-link`
+### `paste-link`
 
 ```sh
-cloudwatch-insights parse-link 'https://eu-north-1.console.aws.amazon.com/cloudwatch/home?region=eu-north-1#logsV2:logs-insights$3FqueryDetail$3D~(...)'
-pbpaste | cloudwatch-insights parse-link                # read URL from stdin
-cloudwatch-insights parse-link --as-raw <url>           # print a `raw` shell command instead
+cloudwatch-insights paste-link                                 # read URL from pasteboard
+cloudwatch-insights paste-link 'https://eu-north-1.console…'   # use a positional URL
+cloudwatch-insights paste-link --prompt                        # ask on stdin
+cloudwatch-insights paste-link --as-raw                        # print a `raw` shell command instead
 ```
 
-The inverse of `link`. Decodes the AWS Console Insights URL and recreates the query state by writing a fresh `current.insights` for the current slot (with `time`, `log-group`, and the query body filled in from the URL) — running `cloudwatch-insights query` afterwards re-runs the same query.
+The inverse of `copy-link`. By default reads the URL from the system pasteboard. A positional argument overrides that; `-p` / `--prompt` asks for the URL interactively. Decodes the AWS Console Insights URL and recreates the query state by writing a fresh `current.insights` for the current slot (with `time`, `log-group`, and the query body filled in from the URL) — running `cloudwatch-insights query` afterwards re-runs the same query.
 
 `--as-raw` instead prints a self-contained `cloudwatch-insights raw …` shell command (a quoted heredoc piping the query body into stdin) and does not touch any state. Useful for sharing a one-shot invocation that someone else can paste into a terminal.
 
-The URL can be passed as a positional argument, via `--url`, or piped on stdin. `-o`/`--output` writes the `.insights` file to a custom path instead of the current slot's `current.insights`.
+`-o`/`--output` writes the `.insights` file to a custom path instead of the current slot's `current.insights`.
 
 ### `show`
 
@@ -140,6 +148,7 @@ Front-matter fields:
 | `env`         | substituted for `{{ env }}` in the query and log group templates    |
 | `app`         | substituted for `{{ app }}` in the query and log group templates (overrides the configured `app`) |
 | `log-group`   | a log group, or an array of log groups                              |
+| `dry`         | when `true`, `query` skips the AWS round-trip after the editor closes (no execution, no results file) |
 
 CLI flags always win over front-matter, and front-matter wins over the repo defaults in `settings.toml`. The result `limit` belongs in the query body itself (`| limit 200`), not the front-matter.
 

--- a/cloudwatch-insights/src/copy-link.mts
+++ b/cloudwatch-insights/src/copy-link.mts
@@ -1,10 +1,11 @@
 /**
- * `cloudwatch-insights link` — generate a shareable AWS Console URL for the
- * query that `cloudwatch-insights query` would otherwise run.
+ * `cloudwatch-insights copy-link` — copy a shareable AWS Console URL for the
+ * query that `cloudwatch-insights query` would otherwise run to the system
+ * pasteboard.
  *
  * Resolution mirrors the query subcommand: --query / --query-file / the
  * repo's current.insights, with front-matter and config defaults filling
- * in time, environment, log groups. We never open the editor here — link
+ * in time, environment, log groups. We never open the editor here — copy-link
  * is a read-only view over what was last edited.
  */
 
@@ -35,7 +36,8 @@ import {
   TimeRangeParseError,
   tryParseRelativeDurationSeconds,
 } from "./time-range.mjs";
-import { hyperlink, openUrlCommand } from "./terminal.mjs";
+import { openUrlCommand, styledLink } from "./terminal.mjs";
+import { copyToPasteboard, PasteboardError } from "./pasteboard.mjs";
 import {
   FrontMatter,
   currentInsightsPath,
@@ -43,7 +45,7 @@ import {
   parseQueryFile,
 } from "./query-file.mjs";
 
-export interface LinkValues {
+export interface CopyLinkValues {
   "log-group"?: string[];
   time?: string;
   query?: string;
@@ -53,11 +55,12 @@ export interface LinkValues {
   profile?: string;
   "preserve-time-window": boolean;
   "account-id"?: string;
+  raw: boolean;
   open: boolean;
   quiet: boolean;
 }
 
-export async function runLink(values: LinkValues): Promise<void> {
+export async function runCopyLink(values: CopyLinkValues): Promise<void> {
   if (values.query && values["query-file"]) {
     fail("--query and --query-file are mutually exclusive", 2);
   }
@@ -119,11 +122,15 @@ export async function runLink(values: LinkValues): Promise<void> {
     process.env.AWS_PROFILE = profile;
   }
 
+  // The diagnostic preamble (region/profile/account/time) is noise when
+  // --raw is set — the caller asked for nothing but the URL.
+  const showDiagnostics = !values.quiet && !values.raw;
+
   const accountId = await resolveAccountId({
     cliAccountId: values["account-id"],
     envConfig,
     region,
-    quiet: values.quiet,
+    quiet: !showDiagnostics,
     environmentLabel: environment,
   });
 
@@ -133,7 +140,7 @@ export async function runLink(values: LinkValues): Promise<void> {
 
   const time = chooseTimeSpec(timeExpr, range, values["preserve-time-window"]);
 
-  if (!values.quiet) {
+  if (showDiagnostics) {
     if (profile && !values.profile) {
       process.stderr.write(`  AWS_PROFILE: ${profile} (from [env.${environment}])\n`);
     }
@@ -160,12 +167,30 @@ export async function runLink(values: LinkValues): Promise<void> {
   });
   const url = buildConsoleLink({ region, queryDetail });
 
+  if (values.raw) {
+    process.stdout.write(url + "\n");
+    if (values.open) openInBrowser(url);
+    return;
+  }
+
+  try {
+    await copyToPasteboard(url);
+  } catch (err) {
+    if (err instanceof PasteboardError) {
+      fail(err.message, 1);
+    }
+    throw err;
+  }
+
   if (process.stdout.isTTY) {
     process.stdout.write(
-      hyperlink(url, "Open in CloudWatch Logs Insights") + "\n",
+      "AWS Console link copied to pasteboard. " +
+        styledLink(url, "Open directly") +
+        "\n",
     );
+  } else {
+    process.stdout.write("AWS Console link copied to pasteboard.\n");
   }
-  process.stdout.write(url + "\n");
 
   if (values.open) {
     openInBrowser(url);
@@ -238,7 +263,7 @@ interface QuerySource {
   frontMatter: FrontMatter;
 }
 
-function resolveQuerySourceReadOnly(values: LinkValues): QuerySource {
+function resolveQuerySourceReadOnly(values: CopyLinkValues): QuerySource {
   if (values.query) {
     return { queryBody: values.query, frontMatter: {} };
   }

--- a/cloudwatch-insights/src/index.mts
+++ b/cloudwatch-insights/src/index.mts
@@ -33,9 +33,17 @@ import {
   updateLatestSymlink,
   writeResults,
 } from "./query-file.mjs";
-import { LinkValues, runLink } from "./link.mjs";
-import { ParseLinkValues, runParseLink } from "./parse-link.mjs";
+import { CopyLinkValues, runCopyLink } from "./copy-link.mjs";
+import { PasteLinkValues, runPasteLink } from "./paste-link.mjs";
 import { RawValues, runRaw } from "./raw.mjs";
+import {
+  buildConsoleLink,
+  buildQueryDetail,
+  TimeSpec,
+} from "./console-link.mjs";
+import { tryParseRelativeDurationSeconds } from "./time-range.mjs";
+import { styledLink } from "./terminal.mjs";
+import { QueryProgress, QueryStatistics } from "./insights.mjs";
 
 const DESCRIPTION = "Download logs from AWS CloudWatch Logs Insights.";
 
@@ -194,6 +202,28 @@ async function runQuery(values: QueryValues): Promise<void> {
     }
   }
 
+  const consoleUrl = buildQueryConsoleUrl({
+    region,
+    logGroups,
+    query: expandedQuery,
+    timeExpr,
+    range,
+  });
+
+  if (frontMatter.dry === true) {
+    if (!values.quiet) {
+      process.stderr.write(
+        `Dry run (front-matter \`dry = true\`); not contacting AWS.\n`,
+      );
+      process.stderr.write(`  log groups: ${logGroups.join(", ")}\n`);
+      process.stderr.write(
+        `  time:       ${range.startTime.toISOString()} → ${range.endTime.toISOString()}\n`,
+      );
+    }
+    if (consoleUrl) emitConsoleLink(consoleUrl);
+    return;
+  }
+
   if (!values.quiet) {
     process.stderr.write(
       `Querying ${logGroups.length} log group(s) from ${range.startTime.toISOString()} ` +
@@ -202,7 +232,7 @@ async function runQuery(values: QueryValues): Promise<void> {
     process.stderr.write(`  log groups: ${logGroups.join(", ")}\n`);
   }
 
-  let lastStatus = "";
+  const progress = createProgressReporter({ quiet: values.quiet });
   const result = await runInsightsQuery({
     client,
     logGroups,
@@ -210,12 +240,9 @@ async function runQuery(values: QueryValues): Promise<void> {
     startTime: range.startTime,
     endTime: range.endTime,
     limit,
-    onStatus: (status) => {
-      if (values.quiet || status === lastStatus) return;
-      lastStatus = String(status);
-      process.stderr.write(`  status: ${status}\n`);
-    },
+    onProgress: progress.update,
   });
+  progress.done();
 
   const flattenFields = defaults.flattenFields ?? [];
   const rows = flattenFields.length === 0
@@ -236,6 +263,8 @@ async function runQuery(values: QueryValues): Promise<void> {
     );
     process.stderr.write(`  ${linkPath} → ${outPath}\n`);
   }
+
+  if (consoleUrl) emitConsoleLink(consoleUrl);
 }
 
 interface QuerySource {
@@ -340,13 +369,13 @@ function resolveLogGroups(args: ResolveLogGroupsArgs): string[] {
 }
 
 // ---------------------------------------------------------------------------
-// link subcommand
+// copy-link subcommand
 // ---------------------------------------------------------------------------
 
-const linkCmd = define({
-  name: "link",
+const copyLinkCmd = define({
+  name: "copy-link",
   description:
-    "Print a shareable AWS Console URL for the query (no editor, no execution)",
+    "Copy a shareable AWS Console URL for the query to the system pasteboard (no editor, no execution)",
   args: {
     "log-group": {
       type: "string",
@@ -395,6 +424,11 @@ const linkCmd = define({
       description:
         "always emit absolute start/end timestamps in the URL, even when -t is a relative duration like 1h",
     },
+    raw: {
+      type: "boolean",
+      default: false,
+      description: "print the URL to stdout and skip the pasteboard copy",
+    },
     open: {
       type: "boolean",
       default: false,
@@ -407,23 +441,19 @@ const linkCmd = define({
     },
   },
   run: async (ctx) => {
-    await runLink(ctx.values as unknown as LinkValues);
+    await runCopyLink(ctx.values as unknown as CopyLinkValues);
   },
 });
 
 // ---------------------------------------------------------------------------
-// parse-link subcommand
+// paste-link subcommand
 // ---------------------------------------------------------------------------
 
-const parseLinkCmd = define({
-  name: "parse-link",
+const pasteLinkCmd = define({
+  name: "paste-link",
   description:
-    "Decode an AWS Console Insights URL and recreate the query state (or print a `raw` shell command with --as-raw)",
+    "Decode an AWS Console Insights URL (default: from the pasteboard) and recreate the query state (or print a `raw` shell command with --as-raw)",
   args: {
-    url: {
-      type: "string",
-      description: "the URL to decode (alternatively pass it as a positional, or pipe it on stdin)",
-    },
     "as-raw": {
       type: "boolean",
       default: false,
@@ -436,6 +466,12 @@ const parseLinkCmd = define({
       description:
         "write the .insights file to this path instead of the current slot's current.insights",
     },
+    prompt: {
+      type: "boolean",
+      short: "p",
+      default: false,
+      description: "prompt for the URL on stdin instead of reading the pasteboard",
+    },
     quiet: {
       type: "boolean",
       default: false,
@@ -446,7 +482,7 @@ const parseLinkCmd = define({
     // gunshi includes the subcommand name as the first positional; drop it
     // so the user-supplied URL (if any) is at index 0.
     const positionals = ((ctx.positionals ?? []) as string[]).slice(1);
-    await runParseLink(ctx.values as unknown as ParseLinkValues, positionals);
+    await runPasteLink(ctx.values as unknown as PasteLinkValues, positionals);
   },
 });
 
@@ -602,6 +638,126 @@ function fail(message: string, code = 1): never {
   process.exit(code);
 }
 
+interface BuildQueryConsoleUrlArgs {
+  region: string | undefined;
+  logGroups: string[];
+  query: string;
+  timeExpr: string;
+  range: { startTime: Date; endTime: Date };
+}
+
+/**
+ * Build a shareable AWS Console URL for the in-progress query, using bare
+ * log-group names (queryBy=logGroupName) so we don't have to look up an
+ * account ID. Returns null when no region is known — without one we can't
+ * pick a Console host.
+ */
+function buildQueryConsoleUrl(args: BuildQueryConsoleUrlArgs): string | null {
+  if (!args.region) return null;
+  const time: TimeSpec = pickTimeSpec(args.timeExpr, args.range);
+  const detail = buildQueryDetail({
+    query: args.query,
+    logGroupArns: args.logGroups,
+    time,
+  });
+  return buildConsoleLink({ region: args.region, queryDetail: detail });
+}
+
+function pickTimeSpec(
+  timeExpr: string,
+  range: { startTime: Date; endTime: Date },
+): TimeSpec {
+  const seconds = tryParseRelativeDurationSeconds(timeExpr);
+  if (seconds !== null) return { kind: "relative", secondsBack: seconds };
+  return {
+    kind: "absolute",
+    startMs: range.startTime.getTime(),
+    endMs: range.endTime.getTime(),
+  };
+}
+
+function emitConsoleLink(url: string): void {
+  if (process.stderr.isTTY) {
+    process.stderr.write(styledLink(url, "Open in AWS Console") + "\n");
+  } else {
+    process.stderr.write(url + "\n");
+  }
+}
+
+interface ProgressReporter {
+  update(progress: QueryProgress): void;
+  done(): void;
+}
+
+/**
+ * Render polling progress on stderr. On a TTY we overwrite a single line
+ * (`\r`-rewriting). Off a TTY we append one line per status change so logs
+ * stay readable.
+ */
+function createProgressReporter(opts: { quiet: boolean }): ProgressReporter {
+  if (opts.quiet) return { update: () => {}, done: () => {} };
+  const tty = !!process.stderr.isTTY;
+  let lastLine = "";
+  let lastStatus = "";
+  let written = false;
+
+  const update = (progress: QueryProgress): void => {
+    const line = formatProgressLine(progress);
+    if (tty) {
+      if (line === lastLine) return;
+      // \x1b[2K erases the current line; \r returns to column 0.
+      process.stderr.write(`\r\x1b[2K  ${line}`);
+      lastLine = line;
+      written = true;
+    } else {
+      const status = String(progress.status);
+      if (status === lastStatus) return;
+      lastStatus = status;
+      process.stderr.write(`  ${line}\n`);
+    }
+  };
+
+  const done = (): void => {
+    if (tty && written) process.stderr.write("\n");
+  };
+
+  return { update, done };
+}
+
+function formatProgressLine(progress: QueryProgress): string {
+  const status = String(progress.status);
+  const stats = formatStatistics(progress.statistics);
+  return stats ? `status: ${status} (${stats})` : `status: ${status}`;
+}
+
+function formatStatistics(stats: QueryStatistics): string {
+  const parts: string[] = [];
+  if (stats.recordsScanned !== undefined) {
+    parts.push(`scanned ${formatCount(stats.recordsScanned)} records`);
+  }
+  if (stats.bytesScanned !== undefined) {
+    parts.push(formatBytes(stats.bytesScanned));
+  }
+  if (stats.recordsMatched !== undefined) {
+    parts.push(`${formatCount(stats.recordsMatched)} matched`);
+  }
+  return parts.join(", ");
+}
+
+function formatCount(n: number): string {
+  if (n < 1_000) return String(n);
+  if (n < 1_000_000) return `${(n / 1_000).toFixed(1)}k`;
+  if (n < 1_000_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+  return `${(n / 1_000_000_000).toFixed(1)}B`;
+}
+
+function formatBytes(n: number): string {
+  if (n < 1024) return `${n} B`;
+  if (n < 1024 ** 2) return `${(n / 1024).toFixed(1)} KiB`;
+  if (n < 1024 ** 3) return `${(n / 1024 ** 2).toFixed(1)} MiB`;
+  return `${(n / 1024 ** 3).toFixed(1)} GiB`;
+}
+
 // ---------------------------------------------------------------------------
 // main entry: unknown commands and `cloudwatch-insights` with no args both
 // fall through to this, which prints a hint.
@@ -613,7 +769,7 @@ const main = define({
   args: {},
   run: () => {
     process.stderr.write(
-      "Usage: cloudwatch-insights <query|raw|link|parse-link|show|edit-config>\n" +
+      "Usage: cloudwatch-insights <query|raw|copy-link|paste-link|show|edit-config>\n" +
         "Run `cloudwatch-insights --help` for details.\n",
     );
     process.exit(2);
@@ -637,8 +793,8 @@ try {
     subCommands: {
       query: queryCmd,
       raw: rawCmd,
-      link: linkCmd,
-      "parse-link": parseLinkCmd,
+      "copy-link": copyLinkCmd,
+      "paste-link": pasteLinkCmd,
       show: showCmd,
       "edit-config": editConfigCmd,
     },

--- a/cloudwatch-insights/src/insights.mts
+++ b/cloudwatch-insights/src/insights.mts
@@ -6,6 +6,17 @@ import {
   StartQueryCommand,
 } from "@aws-sdk/client-cloudwatch-logs";
 
+export interface QueryStatistics {
+  recordsMatched?: number;
+  recordsScanned?: number;
+  bytesScanned?: number;
+}
+
+export interface QueryProgress {
+  status: QueryStatus | string;
+  statistics: QueryStatistics;
+}
+
 export interface RunQueryOptions {
   client: CloudWatchLogsClient;
   logGroups: string[];
@@ -16,7 +27,7 @@ export interface RunQueryOptions {
   /** Polling interval in ms. Defaults to 1000. */
   pollIntervalMs?: number;
   /** Called after each poll so callers can surface progress. */
-  onStatus?: (status: QueryStatus | string) => void;
+  onProgress?: (progress: QueryProgress) => void;
 }
 
 export interface QueryRow {
@@ -25,11 +36,7 @@ export interface QueryRow {
 
 export interface QueryResult {
   rows: QueryRow[];
-  statistics?: {
-    recordsMatched?: number;
-    recordsScanned?: number;
-    bytesScanned?: number;
-  };
+  statistics?: QueryStatistics;
   status: QueryStatus | string;
 }
 
@@ -50,7 +57,7 @@ export async function runInsightsQuery(options: RunQueryOptions): Promise<QueryR
     endTime,
     limit,
     pollIntervalMs = 1_000,
-    onStatus,
+    onProgress,
   } = options;
 
   if (logGroups.length === 0) {
@@ -75,7 +82,14 @@ export async function runInsightsQuery(options: RunQueryOptions): Promise<QueryR
   while (true) {
     const response = await client.send(new GetQueryResultsCommand({ queryId }));
     const status = response.status ?? "Unknown";
-    onStatus?.(status);
+    const statistics: QueryStatistics = response.statistics
+      ? {
+          recordsMatched: response.statistics.recordsMatched,
+          recordsScanned: response.statistics.recordsScanned,
+          bytesScanned: response.statistics.bytesScanned,
+        }
+      : {};
+    onProgress?.({ status, statistics });
 
     if (TERMINAL_STATUSES.has(status)) {
       if (status !== QueryStatus.Complete) {
@@ -84,13 +98,7 @@ export async function runInsightsQuery(options: RunQueryOptions): Promise<QueryR
       return {
         status,
         rows: (response.results ?? []).map(resultFieldsToRow),
-        statistics: response.statistics
-          ? {
-              recordsMatched: response.statistics.recordsMatched,
-              recordsScanned: response.statistics.recordsScanned,
-              bytesScanned: response.statistics.bytesScanned,
-            }
-          : undefined,
+        statistics: response.statistics ? statistics : undefined,
       };
     }
 

--- a/cloudwatch-insights/src/paste-link.mts
+++ b/cloudwatch-insights/src/paste-link.mts
@@ -1,9 +1,13 @@
 /**
- * `cloudwatch-insights parse-link` — inverse of the `link` subcommand.
+ * `cloudwatch-insights paste-link` — inverse of the `copy-link` subcommand.
  *
- * Default behavior: write the query body, log groups, time and (optional)
- * region into `current.insights` for the current slot, so a subsequent
+ * Default behavior: read a CloudWatch Console URL from the system pasteboard
+ * and write the query body, log groups, time and (optional) region into
+ * `current.insights` for the current slot, so a subsequent
  * `cloudwatch-insights query` would re-run the same query.
+ *
+ * A positional argument overrides the pasteboard read; -p/--prompt asks for
+ * the URL on stdin instead.
  *
  * With `--as-raw`: print a self-contained `cloudwatch-insights raw …`
  * shell command (a heredoc piping the query body into stdin) and do not
@@ -12,6 +16,7 @@
 
 import { mkdirSync, writeFileSync } from "fs";
 import { dirname } from "path";
+import { createInterface } from "readline";
 import { stringify as stringifyToml } from "smol-toml";
 
 import {
@@ -20,11 +25,12 @@ import {
   RisonValue,
 } from "./console-link.mjs";
 import { currentInsightsPath } from "./query-file.mjs";
+import { readFromPasteboard, PasteboardError } from "./pasteboard.mjs";
 
-export interface ParseLinkValues {
-  url?: string;
+export interface PasteLinkValues {
   "as-raw": boolean;
   output?: string;
+  prompt: boolean;
   quiet: boolean;
 }
 
@@ -35,8 +41,8 @@ export interface ParsedLinkState {
   query: string;
 }
 
-export async function runParseLink(
-  values: ParseLinkValues,
+export async function runPasteLink(
+  values: PasteLinkValues,
   positionals: string[],
 ): Promise<void> {
   const url = await resolveUrl(values, positionals);
@@ -177,35 +183,49 @@ function shellQuote(s: string): string {
 }
 
 async function resolveUrl(
-  values: ParseLinkValues,
+  values: PasteLinkValues,
   positionals: string[],
 ): Promise<string> {
-  if (values.url && positionals.length > 0) {
-    fail("pass either --url or a positional URL, not both", 2);
+  if (positionals.length > 1) {
+    fail("paste-link takes at most one positional URL", 2);
   }
-  let url = values.url ?? positionals[0];
-  if (!url) {
-    // Read from stdin as a fallback so users can pipe pbpaste / xclip into us.
-    if (!process.stdin.isTTY) {
-      url = await readAllStdin();
+
+  if (positionals.length === 1) {
+    if (values.prompt) {
+      fail("--prompt cannot be combined with a positional URL", 2);
     }
+    return positionals[0].trim();
   }
+
+  if (values.prompt) {
+    return await promptForUrl();
+  }
+
+  let url: string;
+  try {
+    url = await readFromPasteboard();
+  } catch (err) {
+    if (err instanceof PasteboardError) {
+      fail(`${err.message}\n  hint: pass the URL as a positional argument, or use --prompt`, 1);
+    }
+    throw err;
+  }
+  url = url.trim();
   if (!url) {
-    fail("no URL given — pass it as the first argument, --url, or via stdin", 2);
+    fail("pasteboard is empty — pass the URL as a positional argument, or use --prompt", 2);
   }
-  return url.trim();
+  return url;
 }
 
-async function readAllStdin(): Promise<string> {
-  return new Promise((resolve, reject) => {
-    let data = "";
-    process.stdin.setEncoding("utf8");
-    process.stdin.on("data", (chunk) => {
-      data += chunk;
+async function promptForUrl(): Promise<string> {
+  const rl = createInterface({ input: process.stdin, output: process.stderr });
+  try {
+    return await new Promise<string>((resolve) => {
+      rl.question("URL: ", (answer) => resolve(answer.trim()));
     });
-    process.stdin.on("end", () => resolve(data));
-    process.stdin.on("error", reject);
-  });
+  } finally {
+    rl.close();
+  }
 }
 
 function fail(message: string, code = 1): never {

--- a/cloudwatch-insights/src/pasteboard.mts
+++ b/cloudwatch-insights/src/pasteboard.mts
@@ -1,0 +1,116 @@
+/**
+ * Cross-platform clipboard read/write via the host's standard utilities.
+ *
+ *   macOS    → pbcopy / pbpaste
+ *   Windows  → clip / powershell Get-Clipboard
+ *   Linux    → wl-copy/wl-paste (Wayland) or xclip/xsel (X11)
+ */
+
+import { spawn, spawnSync } from "child_process";
+
+export class PasteboardError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "PasteboardError";
+  }
+}
+
+interface CopyCommand {
+  cmd: string;
+  args: string[];
+}
+
+interface PasteCommand {
+  cmd: string;
+  args: string[];
+}
+
+export function copyCommand(platform: NodeJS.Platform = process.platform): CopyCommand {
+  switch (platform) {
+    case "darwin":
+      return { cmd: "pbcopy", args: [] };
+    case "win32":
+      return { cmd: "clip", args: [] };
+    default:
+      if (process.env.WAYLAND_DISPLAY && hasCommand("wl-copy")) {
+        return { cmd: "wl-copy", args: [] };
+      }
+      if (hasCommand("xclip")) {
+        return { cmd: "xclip", args: ["-selection", "clipboard"] };
+      }
+      if (hasCommand("xsel")) {
+        return { cmd: "xsel", args: ["--clipboard", "--input"] };
+      }
+      throw new PasteboardError(
+        "no clipboard tool found (install xclip, xsel, or wl-clipboard)",
+      );
+  }
+}
+
+export function pasteCommand(platform: NodeJS.Platform = process.platform): PasteCommand {
+  switch (platform) {
+    case "darwin":
+      return { cmd: "pbpaste", args: [] };
+    case "win32":
+      return { cmd: "powershell", args: ["-NoProfile", "-Command", "Get-Clipboard"] };
+    default:
+      if (process.env.WAYLAND_DISPLAY && hasCommand("wl-paste")) {
+        return { cmd: "wl-paste", args: ["--no-newline"] };
+      }
+      if (hasCommand("xclip")) {
+        return { cmd: "xclip", args: ["-selection", "clipboard", "-o"] };
+      }
+      if (hasCommand("xsel")) {
+        return { cmd: "xsel", args: ["--clipboard", "--output"] };
+      }
+      throw new PasteboardError(
+        "no clipboard tool found (install xclip, xsel, or wl-clipboard)",
+      );
+  }
+}
+
+export async function copyToPasteboard(text: string): Promise<void> {
+  const { cmd, args } = copyCommand();
+  await new Promise<void>((resolve, reject) => {
+    const child = spawn(cmd, args, { stdio: ["pipe", "ignore", "pipe"] });
+    let stderr = "";
+    child.stderr?.on("data", (chunk) => {
+      stderr += chunk.toString();
+    });
+    child.on("error", (err) =>
+      reject(new PasteboardError(`failed to run ${cmd}: ${err.message}`)),
+    );
+    child.on("close", (code) => {
+      if (code === 0) resolve();
+      else reject(new PasteboardError(`${cmd} exited with ${code}: ${stderr.trim()}`));
+    });
+    child.stdin?.end(text);
+  });
+}
+
+export async function readFromPasteboard(): Promise<string> {
+  const { cmd, args } = pasteCommand();
+  return await new Promise<string>((resolve, reject) => {
+    const child = spawn(cmd, args, { stdio: ["ignore", "pipe", "pipe"] });
+    let stdout = "";
+    let stderr = "";
+    child.stdout?.on("data", (chunk) => {
+      stdout += chunk.toString();
+    });
+    child.stderr?.on("data", (chunk) => {
+      stderr += chunk.toString();
+    });
+    child.on("error", (err) =>
+      reject(new PasteboardError(`failed to run ${cmd}: ${err.message}`)),
+    );
+    child.on("close", (code) => {
+      if (code === 0) resolve(stdout);
+      else reject(new PasteboardError(`${cmd} exited with ${code}: ${stderr.trim()}`));
+    });
+  });
+}
+
+function hasCommand(cmd: string): boolean {
+  const result = spawnSync("which", [cmd], { stdio: "ignore" });
+  return result.status === 0;
+}

--- a/cloudwatch-insights/src/query-file.mts
+++ b/cloudwatch-insights/src/query-file.mts
@@ -25,6 +25,8 @@ export interface FrontMatter {
   env?: string;
   app?: string;
   "log-group"?: string | string[];
+  /** When true, `query` skips AWS execution after the editor closes. */
+  dry?: boolean;
 }
 
 export interface QueryFile {

--- a/cloudwatch-insights/src/raw.mts
+++ b/cloudwatch-insights/src/raw.mts
@@ -69,7 +69,7 @@ export async function runRaw(values: RawValues): Promise<void> {
     startTime: range.startTime,
     endTime: range.endTime,
     limit: values.limit,
-    onStatus: (status) => {
+    onProgress: ({ status }) => {
       if (values.quiet || status === lastStatus) return;
       lastStatus = String(status);
       process.stderr.write(`  status: ${status}\n`);

--- a/cloudwatch-insights/src/terminal.mts
+++ b/cloudwatch-insights/src/terminal.mts
@@ -11,9 +11,53 @@
  */
 const ESC = "\x1b";
 const ST = `${ESC}\\`;
+const RESET = `${ESC}[0m`;
 
 export function hyperlink(url: string, text: string): string {
   return `${ESC}]8;;${url}${ST}${text}${ESC}]8;;${ST}`;
+}
+
+export type Color =
+  | "blue"
+  | "cyan"
+  | "green"
+  | "yellow"
+  | "red"
+  | "magenta"
+  | "gray";
+
+const COLOR_CODES: Record<Color, string> = {
+  blue: "34",
+  cyan: "36",
+  green: "32",
+  yellow: "33",
+  red: "31",
+  magenta: "35",
+  gray: "90",
+};
+
+export interface ColorOptions {
+  color?: Color;
+  bold?: boolean;
+  underline?: boolean;
+}
+
+export function colorize(text: string, opts: ColorOptions): string {
+  const codes: string[] = [];
+  if (opts.bold) codes.push("1");
+  if (opts.underline) codes.push("4");
+  if (opts.color) codes.push(COLOR_CODES[opts.color]);
+  if (codes.length === 0) return text;
+  return `${ESC}[${codes.join(";")}m${text}${RESET}`;
+}
+
+/**
+ * Format a clickable, styled link: an OSC 8 hyperlink whose visible text is
+ * wrapped in a "link-like" SGR style (bright blue + underline by default).
+ * Terminals without OSC 8 support still see the styled text.
+ */
+export function styledLink(url: string, text: string, opts: ColorOptions = { color: "cyan", underline: true }): string {
+  return hyperlink(url, colorize(text, opts));
 }
 
 /**

--- a/cloudwatch-insights/test/paste-link.test.mts
+++ b/cloudwatch-insights/test/paste-link.test.mts
@@ -8,7 +8,7 @@ import {
   buildRawCommand,
   formatRelativeDuration,
   parseLinkToState,
-} from "../src/parse-link.mjs";
+} from "../src/paste-link.mjs";
 import {
   buildConsoleLink,
   buildQueryDetail,
@@ -140,7 +140,7 @@ test("buildRawCommand: escapes single-quotes inside values", () => {
   assert.match(cmd, /-g '\/it'\\''s'/);
 });
 
-test("end-to-end: link → parse-link → recreated current.insights", () => {
+test("end-to-end: copy-link → paste-link → recreated current.insights", () => {
   const url = buildLink({
     region: "eu-north-1",
     accountId: "361629632765",
@@ -150,7 +150,7 @@ test("end-to-end: link → parse-link → recreated current.insights", () => {
   });
   const state = parseLinkToState(url);
 
-  const tmp = mkdtempSync(join(tmpdir(), "cwi-parse-link-"));
+  const tmp = mkdtempSync(join(tmpdir(), "cwi-paste-link-"));
   try {
     const path = join(tmp, "current.insights");
     // Mirror what runParseLink writes (front-matter + body), so we test the

--- a/cloudwatch-insights/test/query-file.test.mts
+++ b/cloudwatch-insights/test/query-file.test.mts
@@ -60,6 +60,13 @@ test("parseQueryFile: empty front-matter is valid (no keys)", () => {
   assert.equal(body, "fields @timestamp");
 });
 
+test("parseQueryFile: dry = true is preserved", () => {
+  const { frontMatter } = parseQueryFile(
+    'time = "1h"\ndry = true\n---\nfields @timestamp',
+  );
+  assert.equal(frontMatter.dry, true);
+});
+
 test("ensureCurrentInsights: seeds with the default template, leaving {{ app }} unexpanded", () => {
   const tmp = mkdtempSync(join(tmpdir(), "cwi-qf-"));
   try {

--- a/cloudwatch-insights/test/terminal.test.mts
+++ b/cloudwatch-insights/test/terminal.test.mts
@@ -1,7 +1,7 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 
-import { hyperlink, openUrlCommand } from "../src/terminal.mjs";
+import { colorize, hyperlink, openUrlCommand, styledLink } from "../src/terminal.mjs";
 
 test("hyperlink: wraps text in OSC 8 escape sequence with ST terminator", () => {
   const url = "https://example.com/foo";
@@ -40,4 +40,26 @@ test("openUrlCommand: linux/other uses xdg-open", () => {
     cmd: "xdg-open",
     args: ["https://x"],
   });
+});
+
+test("colorize: prepends SGR codes and resets", () => {
+  assert.equal(
+    colorize("hi", { color: "cyan", underline: true }),
+    "\x1b[4;36mhi\x1b[0m",
+  );
+});
+
+test("colorize: with no styling returns the text unchanged", () => {
+  assert.equal(colorize("hi", {}), "hi");
+});
+
+test("styledLink: combines OSC 8 hyperlink with SGR styling", () => {
+  const url = "https://example.com/q";
+  const result = styledLink(url, "Open", { color: "cyan", underline: true });
+  // The visible text "Open" sits inside both the OSC 8 sequence and the SGR
+  // style; terminals that ignore OSC 8 still see the styled text.
+  assert.equal(
+    result,
+    `\x1b]8;;${url}\x1b\\\x1b[4;36mOpen\x1b[0m\x1b]8;;\x1b\\`,
+  );
 });


### PR DESCRIPTION
- rename `link` → `copy-link` (copies to system pasteboard by default,
  prints "AWS Console link copied to pasteboard. Open directly" with
  the latter as an OSC 8 hyperlink; `--raw` skips the pasteboard and
  prints just the URL)
- rename `parse-link` → `paste-link` (reads URL from the pasteboard
  by default; positional URL or `-p`/`--prompt` overrides)
- new `src/pasteboard.mts` with copy/read helpers backed by pbcopy/
  pbpaste, clip/Get-Clipboard, wl-clipboard, xclip, or xsel
- after a successful `query` (and in dry mode), emit a styled
  "Open in AWS Console" OSC 8 hyperlink on stderr; bare URL off-TTY
- support `dry = true` in `.insights` front-matter — skip the AWS
  round-trip entirely, just show what would have run plus the link
- live progress on stderr while polling GetQueryResults: TTY rewrites
  a single line ("status: Running (scanned 1.2M records, 456 MiB)");
  off-TTY falls back to one line per status change

Closes #41, #42.