### PR TITLE
Handle broken pipe errors gracefully in main

### DIFF
--- a/cloudwatch-insights/src/main.rs
+++ b/cloudwatch-insights/src/main.rs
@@ -50,7 +50,9 @@ async fn main() -> ExitCode {
     match result {
         Ok(()) => ExitCode::SUCCESS,
         Err(err) => {
-            // Use the chain so that anyhow::Context is preserved.
+            if is_broken_pipe(&err) {
+                return ExitCode::SUCCESS;
+            }
             let msg = err.to_string();
             if let Some(exit_err) = err.downcast_ref::<commands::ExitError>() {
                 eprintln!("error: {}", exit_err.message);
@@ -61,4 +63,12 @@ async fn main() -> ExitCode {
             }
         }
     }
+}
+
+fn is_broken_pipe(err: &anyhow::Error) -> bool {
+    err.chain().any(|cause| {
+        cause
+            .downcast_ref::<std::io::Error>()
+            .is_some_and(|io| io.kind() == std::io::ErrorKind::BrokenPipe)
+    })
 }


### PR DESCRIPTION
## Summary
This change improves error handling in the main function by gracefully handling broken pipe errors, which commonly occur when output is piped to commands like `head` or `grep` that close the pipe early.

## Key Changes
- Added `is_broken_pipe()` helper function that checks if an error chain contains an `std::io::Error` with `BrokenPipe` kind
- Modified error handling in `main()` to return `SUCCESS` exit code when a broken pipe error is detected, instead of treating it as a failure
- This prevents unnecessary error messages when the application's output is intentionally truncated by downstream commands

## Implementation Details
- The helper function uses `anyhow::Error::chain()` to traverse the error chain and locate any underlying `std::io::Error`
- Uses `downcast_ref()` to safely check for the specific error type
- Uses `is_some_and()` to check the error kind in a single expression
- Early return in main prevents the error from being printed to stderr when it's just a broken pipe

https://claude.ai/code/session_018XLgMYMUsjU43EYdouUyLT