### PR TITLE
ci: bump GitHub Actions off Node.js 20

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,18 +9,18 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - uses: pnpm/action-setup@v4
         with:
           version: 10
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: 24
           cache: pnpm
           cache-dependency-path: '**/pnpm-lock.yaml'
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: '25'


### PR DESCRIPTION
GitHub will force JavaScript actions running on Node.js 20 to run on Node.js 24 starting **June 2, 2026**, and will remove Node.js 20 from the runner on **September 16, 2026**.

This bumps the actions used in this repo's workflows to versions whose runtime has migrated to Node.js 24, eliminating the `Node.js 20 actions are deprecated` warning in CI logs.

Action bumps applied:
- `actions/checkout` v1–v4 → v5
- `actions/setup-java` v1–v4 → v5
- `actions/setup-node` v1–v4 → v5
- `actions/cache` v1–v4 → v5
- `actions/upload-artifact` v1–v4 → v5
- `actions/download-artifact` v1–v4 → v5
- `actions/setup-python` v1–v5 → v6
- `actions/github-script` v1–v7 → v8

See: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/